### PR TITLE
docs: v0.4 shipped + Vercel Pro requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,11 +91,13 @@ SUPABASE_SECRET_KEY='sb_secret_...' \
 | GitHub | `william-laverty/ato-mcp` (private) | live |
 | Supabase | project `ato-mcp` (`pznbngklxhkyigmlvruk`), ap-southeast-2 | live; 4 migrations applied; pgvector enabled |
 | Vercel `ato-mcp-web` | Next.js app, root `packages/web` | live at `ato-mcp.com.au` (canonical) |
-| Vercel `ato-mcp-backend` | Functions, root `packages/backend` | live at `api.ato-mcp.com.au` |
-| Local corpus | `~/Library/Application Support/ato-mcp/live/ato.sqlite` | 29,180 docs / 224k chunks |
-| Supabase corpus | `docs` + `chunks` + `anchors` + `definitions` + `thresholds` tables | 29k docs / chunks ongoing (import script) |
+| Vercel `ato-mcp-backend` | Functions, root `packages/backend` | live at `api.ato-mcp.com.au`; **16 serverless functions → requires Vercel Pro** (Hobby caps at 12) |
+| Local corpus | `~/Library/Application Support/ato-mcp/live/ato.sqlite` | 29,180 docs / 224k chunks (stale v0.2 build locally) |
+| Supabase corpus | `docs` + `chunks` + `anchors` + `citations` + `definitions` + `thresholds` | 29,181 docs / 224,585 chunks (complete; 8 thresholds, 23,267 citations) |
 
 The Supabase team ID for the Vercel MCP is `team_UWCodSopgUHNhnJCAGNsJ1uA`. Project IDs: `prj_xREEymkcKg1VwkgvoTXbQjYJIjHt` (web), `prj_ok6AxQ6e1iH8NtV33zpgGoNiYh1t` (backend).
+
+**Operational requirement (v0.4+):** the backend ships **16 serverless functions**, so the `ato-mcp-backend` Vercel project **must be on the Pro plan** — Vercel Hobby caps a deployment at 12 functions, and a 16-function deploy fails at the "Deploying outputs" stage *after a clean build* (no code error, just the cap). Every new tool adds a function; the durable fix is to consolidate the per-tool `api/*.ts` handlers into one dynamic `api/[tool].ts` dispatcher (tracked as a v0.5 issue).
 
 ## MCP servers available
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,8 @@
 # v0.4 handoff — COMPLETE (all 4 hero tools shipped)
 
-All four v0.4 hero tools are shipped on `feat/v0.4-deduction-discovery`. Full test suite green: 155 shared + 79 mcp + 49 backend + 3 web (286 total TS tests).
+All four v0.4 hero tools are **merged to `main` (PR #1) and live in production** (`api.ato-mcp.com.au` — all four routes return 401 unauthenticated = deployed + auth-gated). Full TS suite green: 159 shared + 79 mcp + 49 backend + 3 web (290 total). **Vercel Web Analytics enabled** on the web app (PR #2; `/_vercel/insights/script.js` serving). **The backend now requires the Vercel Pro plan** — 16 serverless functions exceed Hobby's 12-function cap (the deploy fails post-build otherwise). Recommended next step: consolidate the backend tool endpoints into a single dynamic `api/[tool].ts` dispatcher to remove the function-count pressure and shrink bundles.
+
+> Not yet verified: an **authenticated** prod call exercising the new tools' hosted path (RemoteToolForwarder → backend → WasmEmbedder cold-start → Supabase). The 401s prove the routes deploy, not that the tools execute. Run one real authenticated call per tool before calling v0.4 fully battle-tested.
 
 - `deduction_discovery` (tool 1 of 4) — curated 59-row deduction taxonomy, `resolveCitations()` spine, discrete confidence
 - `depreciation_helper` (tool 2 of 4) — deterministic PC/DV/IAWO/SBE-pool/Div 43 schedules

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -80,6 +80,7 @@ Once connected, **I can run the SQL migrations for you** in the next phase. You 
      - `SUPABASE_URL` = your Project URL
      - `SUPABASE_SECRET_KEY` = your secret key
    - Click **Deploy**.
+   - **⚠️ v0.4+ requires Vercel Pro for the backend.** As of v0.4 the backend ships **16 serverless functions** (one per tool/endpoint). Vercel **Hobby caps a deployment at 12 functions**, so the deploy will fail at the "Deploying outputs" stage *after a clean build* on the free plan. Put the `ato-mcp-backend` project on **Pro**. (Future fix: consolidate the per-tool `api/*.ts` handlers into one dynamic `api/[tool].ts` dispatcher — see the v0.5 tracking issue.)
 
 Vercel will now auto-deploy both projects on every push to `main`. Pushes that only touch `packages/web/` won't redeploy the backend (and vice versa) — Vercel's Ignored Build Step detects per-root changes.
 


### PR DESCRIPTION
## Summary
Documentation-only. Records the post-v0.4 reality:
- **CLAUDE.md / RUNBOOK.md**: the backend now ships **16 serverless functions → requires Vercel Pro** (Hobby caps deployments at 12; the deploy fails post-build otherwise). Notes the dynamic-dispatcher consolidation as the durable fix.
- **CLAUDE.md**: corrects the Supabase corpus status (complete; 8 thresholds, 23,267 citations) and flags the local corpus as the stale v0.2 build.
- **HANDOFF.md**: v0.4 merged to `main` and live; analytics enabled; flags the still-unverified authenticated hosted-path smoke.

## Test Plan
- [x] Docs-only; no code paths touched. CI/build unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)