### PR TITLE
v1.0 launch surface: LICENSE, README, tool docs, npm-ready packages

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Something broken in a tool, the corpus, or an install path
+labels: bug
+---
+
+**What happened?**
+
+**Expected behaviour**
+
+**Mode** (local / hosted) and **how installed** (npm / source):
+
+**Tool + arguments** (redact anything personal):
+
+**Versions**: `ato-mcp --version` / Node / OS:
+
+**If a tax-content issue**: link the ATO page / ITAA section that shows the correct position.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+---
+name: Feature request
+about: New tool, corpus source, or capability
+labels: enhancement
+---
+
+**The problem** (what can't an agent do today?)
+
+**Proposed shape** (tool name, inputs, outputs — sketch is fine)
+
+**Who benefits** (which taxpayer shapes / workflows)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Summary
+
+## Test plan
+- [ ] `pnpm -r typecheck && pnpm -r test` green
+- [ ] Pipeline tests if `packages/pipeline` touched: `uv run pytest -k "not slow"`
+
+## Tax-law sources
+<!-- If this encodes a rule/rate/date: link the controlling ITAA section / ruling / ATO page -->

--- a/.github/workflows/corpus-build.yml
+++ b/.github/workflows/corpus-build.yml
@@ -55,9 +55,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="v0.2.$(date -u +%Y.%m)"
+          TAG="corpus-v$(date -u +%Y.%m)"
           gh release create "$TAG" \
             packages/pipeline/corpus-out/*.zst \
             packages/pipeline/corpus-out/manifest.json \
             --title "Corpus $TAG" \
-            --notes "Automated monthly corpus build."
+            --notes "Automated monthly corpus build. Install with: ato-mcp update" \
+            --latest=false

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+name: npm-publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    # Only software releases (v*), never corpus releases (corpus-v*)
+    if: startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # npm provenance
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @ato-mcp/shared build && pnpm --filter @ato-mcp/mcp build
+      - run: pnpm --filter @ato-mcp/shared test && pnpm --filter @ato-mcp/mcp test
+      - name: Publish @ato-mcp/shared
+        run: pnpm --filter @ato-mcp/shared publish --access public --no-git-checks --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish @ato-mcp/mcp
+        run: pnpm --filter @ato-mcp/mcp publish --access public --no-git-checks --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+## 1.0.0 — 2026-06
+
+First public release.
+
+- **Four workflow tools** (`deduction_discovery`, `depreciation_helper`, `bas_prep_checklist`,
+  `audit_risk_check`): cited, structure-aware tax workflows for every Australian taxpayer
+  shape — 59-category deduction taxonomy, deterministic depreciation schedules, tiered BAS
+  checklists, heuristic audit red-flags.
+- **Personal facts layer**: 25-field profile captured once via web onboarding
+  (magic-link auth), served to agents via `get_user_facts`.
+- **Dual deployment modes** sharing one tool core: local (SQLite + sqlite-vec + ONNX,
+  fully offline) and hosted (Vercel + Supabase pgvector at `api.ato-mcp.com.au`).
+- **Corpus**: 29,181 docs / 224,585 chunks — ato.gov.au, ITAA 1997 (4,638 sections,
+  1,929 statutory definitions), 2,127 typed ATO rulings, 23,267-edge citation graph,
+  8 time-keyed thresholds. Monthly rebuild pipeline with sha256-verified releases.
+- **Hardening before launch**: hosted `getThreshold` SETOF unwrap fix, citation-resolution
+  fault tolerance (bounded fan-out, per-leg survival, explicit degradation notes), backend
+  consolidated to a single dynamic dispatcher (16 → 4 serverless functions), corpus update
+  client resilient to mixed software/corpus releases.
+- 317 TypeScript tests + 85 pipeline tests; authenticated end-to-end production verification.
+
+## 0.4.0 — 2026-06
+
+Hero workflow tools shipped (all four), Vercel Web Analytics, Vercel Pro requirement
+documented.
+
+## 0.3.0 — 2026-05
+
+Personal-context release: shared tool core refactor, UserFactsSchema + `get_user_facts`,
+Next.js onboarding at ato-mcp.com.au, hosted backend (Vercel + Supabase + RLS), bearer auth.
+
+## 0.2.0 — 2026-05
+
+Wider corpus: ITAA 1997 ingest, typed law.ato.gov.au rulings, threshold extractors,
+`get_definition` / `get_doc_anchors` / `get_threshold` / `fetch`, release flow scaffolding.
+
+## 0.1.0 — 2026-05
+
+Scaffolding: monorepo, ATO sitemap pipeline, sqlite-vec corpus, MCP server with
+`search` / `get_chunks` / `fetch` / `stats`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,13 +91,13 @@ SUPABASE_SECRET_KEY='sb_secret_...' \
 | GitHub | `william-laverty/ato-mcp` (private) | live |
 | Supabase | project `ato-mcp` (`pznbngklxhkyigmlvruk`), ap-southeast-2 | live; 4 migrations applied; pgvector enabled |
 | Vercel `ato-mcp-web` | Next.js app, root `packages/web` | live at `ato-mcp.com.au` (canonical) |
-| Vercel `ato-mcp-backend` | Functions, root `packages/backend` | live at `api.ato-mcp.com.au`; **16 serverless functions → requires Vercel Pro** (Hobby caps at 12) |
+| Vercel `ato-mcp-backend` | Functions, root `packages/backend` | live at `api.ato-mcp.com.au`; **4 serverless functions** (dynamic `api/[tool].ts` dispatcher + facts/usage_event/onboard_poll) |
 | Local corpus | `~/Library/Application Support/ato-mcp/live/ato.sqlite` | 29,180 docs / 224k chunks (stale v0.2 build locally) |
 | Supabase corpus | `docs` + `chunks` + `anchors` + `citations` + `definitions` + `thresholds` | 29,181 docs / 224,585 chunks (complete; 8 thresholds, 23,267 citations) |
 
 The Supabase team ID for the Vercel MCP is `team_UWCodSopgUHNhnJCAGNsJ1uA`. Project IDs: `prj_xREEymkcKg1VwkgvoTXbQjYJIjHt` (web), `prj_ok6AxQ6e1iH8NtV33zpgGoNiYh1t` (backend).
 
-**Operational requirement (v0.4+):** the backend ships **16 serverless functions**, so the `ato-mcp-backend` Vercel project **must be on the Pro plan** — Vercel Hobby caps a deployment at 12 functions, and a 16-function deploy fails at the "Deploying outputs" stage *after a clean build* (no code error, just the cap). Every new tool adds a function; the durable fix is to consolidate the per-tool `api/*.ts` handlers into one dynamic `api/[tool].ts` dispatcher (tracked as a v0.5 issue).
+**Operational note (v1.0):** the per-tool handlers were consolidated into one dynamic `api/[tool].ts` dispatcher, so the backend ships **4 functions** and no longer presses the Vercel Hobby 12-function cap (the project currently runs on Pro regardless). New tools are added to the dispatcher's `TOOLS` map, not as new files — keep it that way.
 
 ## MCP servers available
 
@@ -125,12 +125,11 @@ Both Supabase and Vercel MCPs are connected to this Claude Code session. Use the
 │    + tools from @ato-mcp/shared/tools                          │
 │                                                                │
 │  if mode === "hosted":                                         │
-│    RemoteStore(api.ato-mcp.com.au, bearer_token)               │
-│    forwards each Store call to backend (CURRENTLY BROKEN —     │
-│    path/name mismatch; see KNOWN ISSUES)                       │
+│    RemoteToolForwarder(api.ato-mcp.com.au, bearer_token)       │
+│    forwards each tool call by name to the backend dispatcher   │
 └────────────────────────────────────────────────────────────────┘
 
-Hosted path (the path RemoteStore should be talking to):
+Hosted path:
 
   ato-mcp.com.au         api.ato-mcp.com.au               Supabase
        (Next.js)              (Vercel functions)          (Postgres+pgvector)
@@ -157,42 +156,23 @@ Adapters:
 
 ### Backend handler convention
 
-Every `packages/backend/api/*.ts` follows this shape:
+All 13 tool endpoints are served by **one dynamic dispatcher**: `packages/backend/api/[tool].ts`.
+It mirrors `packages/mcp/src/server.ts` dispatch — a `TOOLS` map of `name → runner`, with a
+module-level `SupabaseStore`, a lazy `WasmEmbedder` (loaded only for tools that embed), and a
+single `lookupUserFacts(userId)` for facts-dependent tools. Unknown tool → 404; tool errors → 400
+`{kind:"error", message}`. To add a tool: schema in shared, entry in the dispatcher's map — do NOT
+create a new `api/*.ts` file (function-count and bundle-size both regress).
 
-```ts
-import { adapt } from "./_adapter.js";
-import { authMiddleware } from "./_middleware.js";
-import { someTool } from "@ato-mcp/shared/tools/some_tool";
-import { SupabaseStore } from "../src/supabase-store.js";
-
-const store = new SupabaseStore();
-
-async function handler(req: Request): Promise<Response> {
-  const auth = await authMiddleware(req);
-  if (auth instanceof Response) return auth;
-  try {
-    const args = SomeInputSchema.parse(await req.json());
-    return Response.json(await someTool({ store }, args));
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return new Response(JSON.stringify({ kind: "error", message: msg }), {
-      status: 500, headers: { "content-type": "application/json" },
-    });
-  }
-}
-
-export default adapt(handler);
-```
-
-The `adapt()` wrapper exists because Vercel's Node runtime defaults to legacy `(req, res)` style; the adapter converts to/from Web Standard. Do not try to use `export const config = { runtime: 'edge' }` — Edge can't bundle our transitive sharp/onnxruntime-node deps.
+Only non-tool endpoints have their own files: `facts.ts` (PUT), `usage_event.ts`, `onboard_poll.ts`.
+All handlers are written Web-Standard `(req: Request) => Response` and wrapped by `api/_adapter.ts`
+for Vercel's Node runtime. Do not use the Edge runtime — sharp/onnxruntime-node aren't compatible.
 
 ### URLs (Vercel `rewrites` in `packages/backend/vercel.json`)
 
 Public URLs strip the `/api` prefix:
 
-- `api.ato-mcp.com.au/stats` → `api/stats.ts`
-- `api.ato-mcp.com.au/search` → `api/search.ts`
-- etc.
+- `api.ato-mcp.com.au/<tool>` → `api/[tool].ts` (all 13 tools)
+- `api.ato-mcp.com.au/facts|usage_event|onboard_poll` → their own handlers
 
 There is **no `/v1/` versioning** — the spec was updated to drop it. Don't reintroduce versioned paths.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Thanks for helping make Australian tax legible to AI agents. Issues and PRs are welcome.
+
+## Setup
+
+```bash
+pnpm install && pnpm -r build      # Node 22+, pnpm 10 (pinned via packageManager)
+cd packages/pipeline && uv sync    # Python 3.12+ with uv (pipeline only)
+```
+
+## Before you open a PR
+
+```bash
+pnpm -r typecheck
+pnpm -r test                                   # TypeScript suites
+cd packages/pipeline && uv run pytest -k "not slow"   # if you touched the pipeline
+```
+
+All four TS workspaces must be green. CI runs the same commands.
+
+## Layout and conventions
+
+- **Tool logic lives in `packages/shared/src/tools/`** as pure `(deps, args) => result`
+  functions against the `Store`/`Embedder` interfaces. Both the local MCP and the hosted
+  backend run this exact code — never fork behaviour per mode.
+- New tools need: a Zod input schema in `shared/src/tools.ts`, registration in
+  `mcp/src/server.ts`, a dispatch entry in `backend/api/[tool].ts`, a subpath export in
+  `shared/package.json`, unit tests (mock the store/embedder), and a row in `docs/tools.md`.
+- **No advice in a tool's own voice.** Tools return structured data + resolvable citations;
+  the agent does the prose. Every workflow tool carries a disclaimer. This is a hard
+  product rule, not a style preference.
+- No silent failures: throw actionable errors ("Run `ato-mcp onboard`…"), and surface any
+  degraded behaviour explicitly in the output.
+- Corpus-grounded data (e.g. the deduction taxonomy) must cite doc_ids that exist — there
+  are integrity tests for this.
+
+## Tax-law correctness
+
+If a change encodes tax law (a rule, rate, date, or threshold), link the controlling source
+(ITAA section / ruling / ATO page) in the PR description. Time-sensitive figures belong in
+the `thresholds` table — never hardcoded.
+
+## Releases
+
+See [RELEASING.md](RELEASING.md). Corpus releases are automated monthly; software releases
+are tagged `v*`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 William Laverty
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,57 +1,161 @@
+<div align="center">
+
 # ato-mcp
 
-Local-first MCP server for the Australian Taxation Office corpus. v0.1 scaffolding release.
+**The Australian tax knowledge base for AI agents.**
 
-## Status
+Give Claude (or any MCP host) cited, current retrieval over 29,000+ ATO documents —
+plus a personal-facts layer and four tax workflow tools that know *your* situation.
 
-**v0.1** — works locally with a small ATO corpus. Tools: `search`, `get_chunks`, `fetch`, `stats`. See `docs/superpowers/specs/` for the full design and `docs/superpowers/plans/` for the v0.1 plan.
+[ato-mcp.com.au](https://ato-mcp.com.au) · [Tool reference](docs/tools.md) · [Self-hosting](docs/self-hosting.md) · [Changelog](CHANGELOG.md)
+
+[![CI](https://github.com/william-laverty/ato-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/william-laverty/ato-mcp/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/%40ato-mcp%2Fmcp)](https://www.npmjs.com/package/@ato-mcp/mcp)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Node 22+](https://img.shields.io/badge/node-%E2%89%A522-brightgreen)](https://nodejs.org)
+
+</div>
+
+---
+
+Ask your agent *"can I claim my home office?"* and it answers from the actual ATO guidance,
+the actual ITAA 1997 section, and the actual ruling — with citations you can resolve and read —
+instead of from training-data vibes. Tell it once that you're a GST-registered sole trader with
+crypto, and every answer is branched for *your* taxpayer shape.
+
+## What's in the corpus
+
+| Source | Contents |
+|---|---|
+| **ato.gov.au** | 24,500+ guidance pages, forms & instructions, occupation guides, myTax help |
+| **ITAA 1997** | 4,638 sections + 1,929 statutory definitions (point-in-time aware) |
+| **ATO public rulings** | 2,127 rulings across 10 types (TR, TD, GSTR, GSTD, PR, CR, LCR, PCG, MT, FTR) |
+| **Citation graph** | 23,267 cross-references between rulings and legislation |
+| **Thresholds** | Time-keyed scalars (instant asset write-off, GST registration, CGT discount, super caps, …) |
+
+**29,181 documents · 224,585 chunks**, embedded and hybrid-indexed (BM25 + vector), rebuilt monthly.
+
+## The 13 tools
+
+**Retrieval** — `search` (hybrid BM25+vector), `get_chunks`, `get_doc`, `get_doc_anchors`
+(citation graph), `get_definition` (statutory, point-in-time), `get_threshold` (time-keyed
+scalars), `fetch` (live page fetch), `stats`.
+
+**Personal context** — `get_user_facts`: 25 facts captured once at onboarding (business
+structure, GST registration, investments, super type, residency, …) so the agent never re-asks.
+
+**Workflows** — the reason this exists:
+
+| Tool | What it does |
+|---|---|
+| `deduction_discovery` | Surfaces **every deduction category** that plausibly applies to your profile — 59-category curated taxonomy, branched across sole traders, companies, trusts, partnerships, investors and SMSF members, each with live citations and a confidence rating |
+| `depreciation_helper` | Deterministic prime-cost / diminishing-value / instant-write-off / small-business-pool / Div 43 schedules for any asset, with the live IAWO threshold |
+| `bas_prep_checklist` | A tiered, cited BAS checklist for your reporting period — which labels apply, what evidence to gather, the gotchas |
+| `audit_risk_check` | Flags the patterns the ATO scrutinises in a draft return (WRE vs income, rental anomalies, unreported crypto, …) with risk bands and the guidance behind each flag |
+
+Every workflow tool returns **structured data + resolvable ATO citations — never advice in its
+own voice**. See the [full tool reference](docs/tools.md).
 
 ## Quick start
 
+### Hosted mode (recommended — no download)
+
+1. Onboard at **[ato-mcp.com.au/onboard](https://ato-mcp.com.au/onboard)** — magic-link sign-in,
+   a 2-minute facts wizard, and you get a bearer token + install snippet.
+2. Add to Claude Code:
+
 ```bash
-# Install JS deps
-pnpm install
-
-# Build Python pipeline
-cd packages/pipeline && uv sync && cd ../..
-
-# Run tests
-pnpm test
-
-# Build a small corpus (~5 minutes, includes model download)
-cd packages/pipeline && uv run ato-pipeline --out-dir corpus-out && cd ../..
-
-# Install corpus
-node packages/mcp/bin/ato-mcp.js update ./packages/pipeline/corpus-out/ato.sqlite
-
-# Verify
-node packages/mcp/bin/ato-mcp.js stats
-
-# Smoke test (no network)
-bash scripts/smoke.sh
+npm install -g @ato-mcp/mcp
+ato-mcp onboard        # opens the browser, writes ~/.ato-mcp/config.json
+claude mcp add ato-mcp -- ato-mcp mcp
 ```
 
-## Register with Claude Code
+Queries run against `api.ato-mcp.com.au` over TLS. Tool calls are **never logged** — see the
+[privacy policy](https://ato-mcp.com.au/privacy) (it's generated from the database schema, so it
+can't drift from reality).
 
-In `~/.claude/settings.json`:
+### Local mode (private, offline)
+
+Everything on your machine: the corpus is a ~1 GB SQLite file, embeddings run locally via ONNX,
+and no query ever leaves your device.
+
+```bash
+npm install -g @ato-mcp/mcp
+ato-mcp update         # downloads + sha256-verifies the latest corpus release
+claude mcp add ato-mcp -- ato-mcp mcp
+```
+
+> Requires Node 22+ and `zstd` (`brew install zstd` / `apt install zstd`). The corpus snapshot is
+> identical to the one hosted mode serves.
+
+### Any other MCP host
 
 ```json
 {
   "mcpServers": {
-    "ato-mcp": {
-      "command": "node",
-      "args": ["/absolute/path/to/ato-mcp/packages/mcp/bin/ato-mcp.js", "mcp"]
-    }
+    "ato-mcp": { "command": "ato-mcp", "args": ["mcp"] }
   }
 }
 ```
 
-## Layout
+## How it works
 
-- `packages/mcp/` — Node MCP server
-- `packages/pipeline/` — Python corpus builder
-- `packages/shared/` — shared TypeScript types
+```mermaid
+flowchart LR
+    A[Claude Code / MCP host] -- stdio --> B[ato-mcp CLI]
+    B -- "local mode" --> C[(SQLite + sqlite-vec\n+ ONNX embeddings)]
+    B -- "hosted mode (HTTPS + bearer)" --> D[api.ato-mcp.com.au]
+    D --> E[(Supabase Postgres\n+ pgvector, RLS)]
+    F[Python pipeline\nmonthly rebuild] --> C
+    F --> E
+```
+
+One shared TypeScript tool core (`packages/shared`) runs identically in both modes — the only
+difference is the storage adapter (`SqliteStore` vs `SupabaseStore`) and the embedder. Behaviour
+cannot drift between local and hosted.
+
+```
+packages/
+├── shared/    Types, Zod schemas, Store/Embedder interfaces, all 13 tool implementations
+├── mcp/       The npm package: stdio MCP server + CLI (update / onboard / stats / mcp)
+├── backend/   Hosted mode: Vercel functions over Supabase Postgres + pgvector
+├── web/       ato-mcp.com.au — Next.js onboarding, account, schema-driven privacy policy
+└── pipeline/  Python (uv) corpus builder: scrape → clean → chunk → embed → package
+```
+
+## Privacy, by construction
+
+- **Local mode:** queries never leave your machine. Full stop.
+- **Hosted mode:** no tool names, no query content, no results are ever stored — the analytics
+  schema physically has nowhere to put them. The [privacy page](https://ato-mcp.com.au/privacy)
+  is rendered from `UserFactsSchema` at build time and a contract test fails if any stored field
+  is undocumented.
+- Per-user rows are isolated with Postgres row-level security; bearer tokens are stored as
+  SHA-256 hashes and revocable from the account page.
+- The entire stack — including the hosted backend — is in this repository. Verify, don't trust.
+
+## Development
+
+```bash
+pnpm install && pnpm -r build
+pnpm -r test            # TypeScript suites (shared, mcp, backend, web)
+cd packages/pipeline && uv sync && uv run pytest -k "not slow"
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for conventions, [docs/self-hosting.md](docs/self-hosting.md)
+to run your own hosted stack, and [RELEASING.md](RELEASING.md) for the release process.
+
+## Important disclaimer
+
+ato-mcp is **information infrastructure, not tax advice**. It retrieves and structures published
+ATO material and computes deterministic schedules; it does not consider your full circumstances
+and it is not a registered tax agent service. Confidence ratings and risk bands are heuristic
+indicators, not professional judgement. Verify material decisions with a registered tax agent —
+and read the [terms](https://ato-mcp.com.au/terms).
+
+ATO content remains subject to ATO publication terms. ITAA 1997 text is reproduced from the
+Federal Register of Legislation under its open licensing.
 
 ## License
 
-MIT. ATO content remains subject to the ATO's publication terms.
+[MIT](LICENSE) © William Laverty

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,36 @@
+# Releasing
+
+## Software releases (npm)
+
+The publishable packages are `@ato-mcp/shared` and `@ato-mcp/mcp` (mcp depends on shared;
+publish shared first — `pnpm publish` rewrites the `workspace:*` range automatically).
+
+One-time setup (repo owner):
+1. Create the npm org `ato-mcp` (https://www.npmjs.com/org/create) and an automation token.
+2. `gh secret set NPM_TOKEN` with that token (enables the publish workflow).
+
+Cutting a release:
+```bash
+# bump versions in packages/shared/package.json + packages/mcp/package.json (keep in lockstep)
+pnpm -r build && pnpm -r test
+git tag v1.0.0 && git push origin v1.0.0
+gh release create v1.0.0 --title "v1.0.0" --notes-file <(sed -n '/^## 1.0.0/,/^## /p' CHANGELOG.md)
+```
+The `npm-publish` workflow publishes both packages on the `v*` release. Manual fallback:
+```bash
+pnpm --filter @ato-mcp/shared publish --access public --no-git-checks
+pnpm --filter @ato-mcp/mcp publish --access public --no-git-checks
+```
+
+## Corpus releases
+
+`corpus-build.yml` runs monthly (or via workflow_dispatch): scrape → embed → package →
+GitHub release tagged `corpus-vYYYY.MM` with `ato-corpus-v*.sqlite.zst` + `manifest.json`,
+marked `--latest=false` so software releases stay "latest". The client (`ato-mcp update`)
+selects the newest release that carries a corpus asset, so the two release families never
+conflict. If ato.gov.au blocks CI scraping, build from a machine that can reach it and run
+`uv run ato-pipeline package --db <ato.sqlite> ...` + `gh release create` manually.
+
+A corpus release must have: matching `embedding_model` in the manifest
+(`sentence-transformers/all-MiniLM-L6-v2`), correct `corpus_sha256` (of the *uncompressed*
+SQLite), and the standard table counts sanity-checked (docs ≥ 29k, thresholds = 8).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Email **developer@william-laverty.com** with details (or use GitHub's private vulnerability
+reporting on this repository). Please do not open public issues for security reports.
+You'll get an acknowledgement within 72 hours.
+
+## Scope
+
+- The hosted API (`api.ato-mcp.com.au`) and web app (`ato-mcp.com.au`)
+- The `@ato-mcp/mcp` npm package and corpus update mechanism
+- The Supabase row-level-security model isolating per-user data
+
+## Design notes relevant to researchers
+
+- Bearer tokens are stored only as SHA-256 hashes; tokens are revocable per-user.
+- Corpus downloads are sha256-verified against a release manifest before install.
+- Hosted tool calls are not logged or retained (no query/result storage exists in the schema).
+- Known limitation: API rate-limiting is per-instance in-memory (documented in the code);
+  abuse-resistance hardening is tracked in the issue tracker.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,32 @@
+# Self-hosting the hosted mode
+
+Local mode needs no infrastructure — this guide is for running your own *hosted* stack
+(your own Supabase + Vercel) instead of api.ato-mcp.com.au.
+
+## You need
+- A Supabase project (pgvector enabled) — free tier works for one user
+- A Vercel account (the backend ships 4 serverless functions)
+- A built corpus (`ato.sqlite`) — `ato-mcp update` then use `~/Library/Application
+  Support/ato-mcp/live/ato.sqlite`, or build via `packages/pipeline`
+
+## Steps
+
+1. **Migrations** — run `packages/backend/migrations/0001..0004` in order against your
+   Supabase database (SQL editor or psql). 0001 creates the corpus schema, 0002 users,
+   0003 the search RPCs, 0004 row-level security.
+2. **Import the corpus**:
+   ```bash
+   SUPABASE_URL='https://<ref>.supabase.co' \
+   SUPABASE_SECRET_KEY='sb_secret_...' \
+     pnpm --filter @ato-mcp/mcp exec tsx scripts/import-corpus.ts
+   ```
+3. **Deploy `packages/backend` to Vercel** — root directory `packages/backend`, env vars
+   `SUPABASE_URL` + `SUPABASE_SECRET_KEY`. The repo's `vercel.json` handles install/build
+   and URL rewrites.
+4. **Deploy `packages/web`** similarly (root `packages/web`) with the env vars from
+   `RUNBOOK.md` if you want the onboarding UI; otherwise insert a user + sha256 token hash
+   into `users`/`bearer_tokens` directly.
+5. **Point the client at your stack** — in `~/.ato-mcp/config.json` set `mode: "hosted"`,
+   `api_endpoint: "https://your-api.example.com"`, `bearer_token: "..."`.
+
+See `RUNBOOK.md` for the original step-by-step deployment log and gotchas.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,762 @@
+# ato-mcp tool reference
+
+ato-mcp exposes 13 MCP tools (identical surface in local and hosted mode). Every tool returns structured JSON; search hits and citations carry resolvable identifiers — pass a `chunk_id` to [`get_chunks`](#get_chunks) for the passage and its neighbours, or a `doc_id` to [`get_doc`](#get_doc) for the full document.
+The personal-context tool ([`get_user_facts`](#get_user_facts)) and the four workflow tools ([`deduction_discovery`](#deduction_discovery), [`depreciation_helper`](#depreciation_helper), [`bas_prep_checklist`](#bas_prep_checklist), [`audit_risk_check`](#audit_risk_check)) require completed onboarding (`ato-mcp onboard`); they throw until personal facts are set.
+Tool failures are returned as MCP error content of the form `{"kind": "error", "message": "..."}`.
+
+### Citations
+
+The workflow tools attach **Citation** objects, resolved live from the corpus (hybrid keyword + vector search, de-duplicated to the best chunk per document):
+
+```json
+{ "chunk_id": "…", "doc_id": "…", "title": "…", "snippet": "…", "score": 0.03 }
+```
+
+| field | meaning |
+|---|---|
+| `chunk_id` | Corpus chunk identifier (`<doc_id>#<ord>`) — resolve with `get_chunks`. |
+| `doc_id` | Parent document identifier — resolve with `get_doc`. |
+| `title` | Parent document title. |
+| `snippet` | Short extract from the cited chunk. |
+| `score` | Retrieval relevance score (rank-fusion value; comparable within one response only). |
+
+If live citation resolution is partially degraded under load, a workflow tool still returns its full result with fewer (or no) citations and says so in `notes` — it never silently drops citations and never fails the whole call for that reason.
+
+**Point-in-time (`pit`):** several retrieval tools accept `pit`, an ISO date (`YYYY-MM-DD`). Results are restricted to content effective at that date. Workflow tools derive `pit` internally from `fy` (30 June of the ending year).
+
+### Contents
+
+**Retrieval tools**
+[`search`](#search) · [`get_chunks`](#get_chunks) · [`get_doc`](#get_doc) · [`get_doc_anchors`](#get_doc_anchors) · [`get_definition`](#get_definition) · [`get_threshold`](#get_threshold) · [`fetch`](#fetch) · [`stats`](#stats)
+
+**Personal context**
+[`get_user_facts`](#get_user_facts)
+
+**Workflow tools**
+[`deduction_discovery`](#deduction_discovery) · [`depreciation_helper`](#depreciation_helper) · [`bas_prep_checklist`](#bas_prep_checklist) · [`audit_risk_check`](#audit_risk_check)
+
+[Disclaimers](#disclaimers)
+
+---
+
+# Retrieval tools
+
+## search
+
+Hybrid BM25 + vector search over the ATO corpus (ato.gov.au guidance, ITAA 1997 legislation, ATO public rulings). `hybrid` mode runs the keyword and vector legs in parallel, over-fetches each, and fuses them with reciprocal-rank fusion; `keyword` and `vector` run a single leg. Returns the top-k chunks, each carrying `chunk_id`/`doc_id` for follow-up retrieval.
+
+### Input
+
+| field | type | required | default | notes |
+|---|---|---|---|---|
+| `query` | string | yes | — | Non-empty natural-language or keyword query. |
+| `k` | integer | no | `10` | 1–50. Number of hits returned. |
+| `mode` | string | no | `"hybrid"` | One of `"hybrid"`, `"vector"`, `"keyword"`. |
+| `source` | string[] | no | — | Accepted by the input schema; not yet applied as a filter. |
+| `doc_type` | string[] | no | — | Accepted by the input schema; not yet applied as a filter. |
+| `jurisdiction` | string | no | — | Accepted by the input schema; not yet applied as a filter. |
+| `pit` | string | no | — | Point-in-time date `YYYY-MM-DD`; restricts to content effective at that date. |
+| `include_old` | boolean | no | `false` | Accepted by the input schema; not yet applied as a filter. |
+
+### Output
+
+- `query`, `mode` — echo of the request.
+- `hits` — array of hit objects:
+  - `chunk_id` — chunk identifier (`<doc_id>#<ord>`).
+  - `doc_id` — parent document identifier.
+  - `ord` — chunk position within the document.
+  - `text` — full chunk text.
+  - `heading_path` — heading breadcrumb (array of strings).
+  - `score` — relevance score (RRF-fused in hybrid mode).
+  - `title`, `url`, `doc_type` — parent document metadata.
+  - `snippet` — short extract.
+
+### Example
+
+```json
+{ "query": "working from home fixed rate method", "k": 3 }
+```
+
+Response (abridged):
+
+```json
+{
+  "query": "working from home fixed rate method",
+  "mode": "hybrid",
+  "hits": [
+    {
+      "chunk_id": "ato:individuals-and-families/income-deductions-offsets-and-records/deductions-you-can-claim/working-from-home-expenses#4",
+      "doc_id": "ato:individuals-and-families/income-deductions-offsets-and-records/deductions-you-can-claim/working-from-home-expenses",
+      "title": "Working from home expenses",
+      "snippet": "…fixed rate method … cents per hour you work from home…",
+      "score": 0.032,
+      "doc_type": "ATO_GUIDE",
+      "url": "https://www.ato.gov.au/…",
+      "heading_path": ["…"],
+      "ord": 4,
+      "text": "…"
+    }
+  ]
+}
+```
+
+**Errors:** throws `Corpus not installed. Run 'ato-mcp update' to download the latest corpus, then retry.` when no local corpus is present.
+
+## get_chunks
+
+Fetch chunk bodies by `chunk_id`, optionally widened with neighbouring chunks (`±N` by position) from the same document. Use it to expand a `search` hit or workflow citation into enough surrounding context to quote accurately.
+
+### Input
+
+| field | type | required | default | notes |
+|---|---|---|---|---|
+| `chunk_ids` | string[] | yes | — | 1–50 ids, each non-empty. |
+| `neighbours` | integer | no | `0` | 0–5. Also return up to N adjacent chunks either side of each id. |
+| `pit` | string | no | — | Point-in-time date `YYYY-MM-DD`. |
+
+### Output
+
+- `chunks` — array of chunk records in the same shape as `search` hits (`chunk_id`, `doc_id`, `ord`, `text`, `heading_path`, `score`, `title`, `url`, `doc_type`, `snippet`).
+
+### Example
+
+```json
+{ "chunk_ids": ["legis:c2004a05138/40-25#0"], "neighbours": 1 }
+```
+
+Response (abridged):
+
+```json
+{
+  "chunks": [
+    { "chunk_id": "legis:c2004a05138/40-25#0", "doc_id": "legis:c2004a05138/40-25", "title": "ITAA 1997 s 40-25", "text": "…deduct an amount equal to the decline in value…", "ord": 0, "…": "…" },
+    { "chunk_id": "legis:c2004a05138/40-25#1", "…": "…" }
+  ]
+}
+```
+
+**Errors:** throws `Corpus not installed. Run 'ato-mcp update'.` when no local corpus is present.
+
+## get_doc
+
+Fetch a full document by `doc_id`: its metadata record, the cleaned HTML body, and the list of in-document anchors (each anchor maps to a `chunk_id`). Use after `search`/citations when chunk-level context is not enough.
+
+### Input
+
+| field | type | required | default | notes |
+|---|---|---|---|---|
+| `doc_id` | string | yes | — | e.g. `legis:c2004a05138/40-75` or `ato:individuals-and-families/…`. |
+| `pit` | string | no | — | Accepted by the input schema; not used by the current implementation. |
+
+### Output
+
+- `doc` — document metadata: `doc_id`, `source` (`ato` \| `legislation` \| `austlii` \| `state_revenue`), `url`, `title`, `jurisdiction`, `doc_type`, `effective_from`, `effective_to`, `published_at`, `retrieved_at`, `metadata`.
+- `cleaned_html` — sanitised HTML body, or `null`.
+- `anchors` — array of `{ anchor_id, anchor_name, chunk_id }` for in-document targets.
+
+### Example
+
+```json
+{ "doc_id": "legis:c2004a05138/328-180" }
+```
+
+Response (abridged):
+
+```json
+{
+  "doc": { "doc_id": "legis:c2004a05138/328-180", "source": "legislation", "title": "ITAA 1997 s 328-180", "doc_type": "LEGISLATION_ITAA1997", "url": "…", "retrieved_at": "…", "…": "…" },
+  "cleaned_html": "<h1>328-180 …</h1>…",
+  "anchors": [ { "anchor_id": "…", "anchor_name": "…", "chunk_id": "legis:c2004a05138/328-180#0" } ]
+}
+```
+
+**Errors:** throws `Corpus not installed. Run 'ato-mcp update'.` when no local corpus is present; throws `Document not found: <doc_id>` for an unknown id.
+
+## get_doc_anchors
+
+List a document's in-document anchors plus its citation graph: inbound edges (chunks elsewhere in the corpus that cite this document) and outbound edges (documents this document's chunks cite). Useful for walking from a ruling to the sections it interprets, or from a section to everything that cites it.
+
+### Input
+
+| field | type | required | default | notes |
+|---|---|---|---|---|
+| `doc_id` | string | yes | — | Document identifier. |
+
+### Output
+
+- `anchors` — array of `{ anchor_id, doc_id, anchor_name, chunk_id }`.
+- `inbound` — citation edges pointing at this document: `{ from_chunk_id, to_doc_id, to_anchor, citation_kind }`.
+- `outbound` — citation edges from this document's chunks, same shape.
+
+### Example
+
+```json
+{ "doc_id": "legis:c2004a05138/8-1" }
+```
+
+Response (abridged):
+
+```json
+{
+  "anchors": [ { "anchor_id": "…", "doc_id": "legis:c2004a05138/8-1", "anchor_name": "…", "chunk_id": "legis:c2004a05138/8-1#0" } ],
+  "inbound": [ { "from_chunk_id": "ato-law:TR/2024/3#12", "to_doc_id": "legis:c2004a05138/8-1", "to_anchor": null, "citation_kind": "…" } ],
+  "outbound": [ "…" ]
+}
+```
+
+**Errors:** throws `Corpus not installed. Run 'ato-mcp update'.` when no local corpus is present.
+
+## get_definition
+
+Look up the statutory definition of a term (e.g. from the ITAA 1997 dictionary), point-in-time aware. When there is no statutory match, falls back to a clearly labelled ordinary-meaning result instead of failing. The caller MUST respect `kind`: `"statutory"` is a defined legal term; `"ordinary"` is not, and must not be presented as one.
+
+### Input
+
+| field | type | required | default | notes |
+|---|---|---|---|---|
+| `term` | string | yes | — | Term to define, e.g. `"depreciating asset"`. |
+| `pit` | string | no | today | Point-in-time date `YYYY-MM-DD`; defaults to today's date. |
+| `jurisdiction` | string | no | `"AU"` | Corpus is Commonwealth (AU) only today. |
+
+### Output
+
+- `term` — echo of the request.
+- `kind` — `"statutory"` or `"ordinary"`.
+- `source` — statutory only: `{ doc_id, anchor, citation }` for the defining provision.
+- `body` — the definition text. For ordinary-meaning results, carries an explicit WordNet attribution (when a WordNet provider is wired), or the sentence `No statutory definition found for "<term>".`
+- `effective_from`, `effective_to` — statutory only: validity window (nullable).
+- `alternatives` — statutory only: additional statutory matches as `{ doc_id, citation, body }`.
+
+### Example
+
+```json
+{ "term": "small business entity", "pit": "2026-06-30" }
+```
+
+Response (abridged):
+
+```json
+{
+  "term": "small business entity",
+  "kind": "statutory",
+  "source": { "doc_id": "legis:c2004a05138/995-1", "anchor": "…", "citation": "legis:c2004a05138/995-1" },
+  "body": "small business entity has the meaning given by section 328-110…",
+  "effective_from": "…",
+  "effective_to": null,
+  "alternatives": []
+}
+```
+
+**Errors:** throws `Corpus not installed. Run 'ato-mcp update'.` when no local corpus is present. A missing definition does not throw — it returns `kind: "ordinary"`.
+
+## get_threshold
+
+Time-keyed scalar tax fact lookup, point-in-time aware. The corpus currently carries 8 thresholds: `gst_registration_threshold`, `gst_registration_threshold_nonprofit`, `instant_asset_write_off`, `cgt_discount_individual`, `super_concessional_cap`, `tax_free_threshold`, `low_income_tax_offset_max`, `small_business_income_tax_offset_cap`.
+
+### Input
+
+| field | type | required | default | notes |
+|---|---|---|---|---|
+| `name` | string | yes | — | Threshold key (see list above). |
+| `pit` | string | no | today | Date the threshold must be effective at (`YYYY-MM-DD`). |
+
+### Output
+
+A single threshold row:
+
+- `name` — threshold key.
+- `value` — numeric value.
+- `unit` — `"AUD"` for dollar amounts, `"percent"` for rates.
+- `effective_from`, `effective_to` — validity window (nullable).
+- `source_doc_id`, `source_anchor` — provenance pointers into the corpus (nullable).
+
+### Example
+
+```json
+{ "name": "instant_asset_write_off", "pit": "2026-06-30" }
+```
+
+Response (abridged):
+
+```json
+{
+  "name": "instant_asset_write_off",
+  "value": 20000,
+  "unit": "AUD",
+  "effective_from": "2023-07-01",
+  "effective_to": null,
+  "source_doc_id": "ato:businesses-and-organisations/…/instant-asset-write-off",
+  "source_anchor": null
+}
+```
+
+**Errors:** throws `Corpus not installed. Run 'ato-mcp update'.` when no local corpus is present; throws `Threshold not found: <name> at <pit>` when no row is effective at the date.
+
+## fetch
+
+Live-fetch a document over HTTPS by scheme-prefixed URI — for content newer than, or outside, the installed corpus. Does not require a corpus. Scheme mapping:
+
+| scheme | resolves to |
+|---|---|
+| `ato:<path>` | `https://www.ato.gov.au/<path>` |
+| `ato-law:<docid>` | `https://www.ato.gov.au/law/view.htm?docid=<docid>` |
+| `legis:<act>/<section>` | `https://www.legislation.gov.au/Latest/<act>/<section>` |
+| `staterev-<juris>:<path>` | the state revenue office site for `nsw`, `vic`, `qld`, `sa`, `wa`, `tas`, `act`, `nt` |
+
+### Input
+
+| field | type | required | default | notes |
+|---|---|---|---|---|
+| `uri` | string | yes | — | Non-empty, scheme-prefixed URI (see table above). |
+
+### Output
+
+- `uri` — echo of the request.
+- `url` — the resolved HTTPS URL fetched.
+- `status` — HTTP status code.
+- `content_type` — response `content-type` header, or `null`.
+- `body` — response body text; empty string when `status` is not 200.
+
+### Example
+
+```json
+{ "uri": "ato-law:PCG/2023/1" }
+```
+
+Response (abridged):
+
+```json
+{
+  "uri": "ato-law:PCG/2023/1",
+  "url": "https://www.ato.gov.au/law/view.htm?docid=PCG/2023/1",
+  "status": 200,
+  "content_type": "text/html; charset=utf-8",
+  "body": "<!DOCTYPE html>…"
+}
+```
+
+**Errors:** throws `Unsupported URI scheme: <uri>` for unknown schemes (including an unrecognised `staterev-` jurisdiction). A non-200 HTTP response is not an error — it is reported via `status` with an empty `body`.
+
+## stats
+
+Report corpus installation status, schema version, and document/chunk counts. The cheapest health check: call it first to confirm a corpus is installed and how stale it is. Never throws — an uninstalled corpus is reported, not raised.
+
+### Input
+
+No parameters (`{}`).
+
+### Output
+
+- `installed` — whether a corpus database is present.
+- `schema_version` — corpus schema version (e.g. `"0.3.0"`), or `null`.
+- `docs` — number of documents.
+- `chunks` — number of chunks.
+- `data_dir` — the ato-mcp data directory.
+- `corpus_path` — full path of the corpus SQLite file.
+- `staleness_days` — days since the corpus was built, or `null`.
+
+### Example
+
+```json
+{}
+```
+
+Response (abridged):
+
+```json
+{
+  "installed": true,
+  "schema_version": "0.3.0",
+  "docs": 29180,
+  "chunks": 224585,
+  "data_dir": "/Users/you/Library/Application Support/ato-mcp",
+  "corpus_path": "…/ato-mcp/live/ato.sqlite",
+  "staleness_days": 12
+}
+```
+
+**Errors:** none. When no corpus is installed, returns `installed: false` with zero counts.
+
+---
+
+# Personal context
+
+## get_user_facts
+
+Return the authenticated user's personal tax facts captured during onboarding — state, residency, ABN/business structure, GST registration, household and investment flags, and the current financial year. Call once when a session starts and reason from the result throughout; the workflow tools read the same facts server-side.
+
+### Input
+
+No parameters (`{}`).
+
+### Output
+
+- `facts` — the validated UserFacts object:
+
+| field | type | notes |
+|---|---|---|
+| `given_name` | string | |
+| `state` | enum | `NSW` `VIC` `QLD` `WA` `SA` `TAS` `ACT` `NT` |
+| `residency_status` | enum | `resident` `non_resident` `temporary_resident` `working_holiday_maker` |
+| `has_abn` | boolean | |
+| `abn` | string? | Present when `has_abn`; passes the ABR modulus-89 checksum. |
+| `business_structure` | enum | `sole_trader` `partnership` `company` `trust` `none` |
+| `business_name` | string? | |
+| `industry_code` | string? | Validated ANZSIC code. |
+| `occupation` | string? | |
+| `gst_registered` | boolean | |
+| `gst_period` | enum | `monthly` `quarterly` `annual` `n/a` — `n/a` iff not registered. |
+| `payg_instalments` | boolean | |
+| `fbt_payer` | boolean | |
+| `has_spouse` | boolean | |
+| `dependants` | integer | 0–20 |
+| `hecs_help_debt` | boolean | |
+| `private_health_insurance` | boolean | |
+| `has_investment_property` | boolean | |
+| `has_shares_or_managed_funds` | boolean | |
+| `has_crypto` | boolean | |
+| `super_fund_type` | enum | `industry` `retail` `smsf` `unsure` `none` |
+| `current_fy` | string | `YYYY-YY`, e.g. `"2025-26"`. |
+| `prior_fy_lodged` | boolean | |
+| `accepted_disclaimer_at` | string | Timestamp. |
+| `facts_updated_at` | string | Timestamp. |
+| `schema_version` | literal `1` | |
+
+- `mode` — `"local"` or `"hosted"`.
+- `fetched_from` — `"config_file"` (local config.json) or `"hosted_api"`.
+
+### Example
+
+```json
+{}
+```
+
+Response (abridged):
+
+```json
+{
+  "facts": {
+    "given_name": "Daisy",
+    "state": "NSW",
+    "residency_status": "resident",
+    "business_structure": "sole_trader",
+    "has_abn": true,
+    "abn": "51824753556",
+    "gst_registered": true,
+    "gst_period": "quarterly",
+    "has_crypto": true,
+    "current_fy": "2025-26",
+    "…": "…"
+  },
+  "mode": "local",
+  "fetched_from": "config_file"
+}
+```
+
+**Errors:** throws `Personal facts not set. Run 'ato-mcp onboard' to complete the web onboarding flow.` when onboarding has not been completed.
+
+---
+
+# Workflow tools
+
+All four workflow tools require personal facts (onboarding) and an installed corpus. Each result includes [`citations`](#citations) per item, a `notes` array (including a degradation note if citation resolution was impaired), and a `disclaimer` string.
+
+## deduction_discovery
+
+Surface every deduction-related category that plausibly applies to the user's tax profile, drawn from a curated taxonomy filtered by their facts. Branches across all taxpayer structures (individual, sole trader, partnership, company, trust, SMSF member), tags each category as belonging on the personal or business-entity return, types it by kind (deduction, offset, CGT event, disallowance, precondition, strategy), and attaches live thresholds, fresh corpus citations, and a discrete confidence rating. Optionally pass `activity` (a free-text spend description) to have the best-matching category identified.
+
+### Input
+
+| field | type | required | default | notes |
+|---|---|---|---|---|
+| `activity` | string | no | — | Free-text activity/spend to match against surfaced categories. |
+| `fy` | string | no | user's `current_fy` fact | Format `YYYY-YY` (e.g. `"2025-26"`); validation error otherwise. |
+| `k_citations` | integer | no | `3` | 1–5 citations resolved per category. |
+| `include_low_confidence` | boolean | no | `true` | Set `false` to drop low-confidence categories. |
+
+### Output
+
+- `fy` — financial year analysed.
+- `taxpayer_profile` — `{ business_structure, residency_status, has_abn, occupation?, industry_code?, flags[] }`; `flags` lists the fact flags that drove filtering (e.g. `gst_registered`, `has_crypto`, `smsf`).
+- `activity` — echo (only when provided).
+- `categories` — array of surfaced categories, ATO focus areas first, then by kind and confidence:
+  - `id`, `label` — category identity.
+  - `kind` — `deduction` \| `offset` \| `cgt_event` \| `disallowance` \| `precondition` \| `strategy`.
+  - `return_context` — `personal` or `business_entity` (which return it belongs on).
+  - `confidence`, `confidence_reason` — `high` \| `medium` \| `low` with a one-line justification.
+  - `applies_because` — why your facts triggered it.
+  - `examples` — example expenses (array).
+  - `substantiation` — the records required.
+  - `consider_prompt` — a question to ask the user.
+  - `ato_focus_area` — boolean; current ATO scrutiny area.
+  - `legal_basis` — provision/ruling reference string.
+  - `thresholds` — live threshold rows (same shape as `get_threshold`).
+  - `citations` — [Citation](#citations) array.
+  - `residency_caveat`, `fy_note` — optional caveats.
+- `matched_activity` — `{ category_id, rationale }` for the best `activity` match, or `null`.
+- `counts` — per-kind totals (`deduction`, `offset`, `cgt_event`, `disallowance`, `precondition`, `strategy`).
+- `notes` — structural caveats (entity-return split, PSI, residency) plus any citation-degradation note.
+- `disclaimer` — fixed not-tax-advice statement.
+
+### Example
+
+```json
+{ "activity": "new laptop for client work", "k_citations": 2 }
+```
+
+Response (abridged):
+
+```json
+{
+  "fy": "2025-26",
+  "taxpayer_profile": { "business_structure": "sole_trader", "residency_status": "resident", "has_abn": true, "flags": ["gst_registered", "has_crypto"] },
+  "activity": "new laptop for client work",
+  "categories": [
+    {
+      "id": "wre_tools_equipment",
+      "label": "Tools, equipment and depreciating assets used for work (D5)",
+      "kind": "deduction",
+      "return_context": "personal",
+      "confidence": "high",
+      "confidence_reason": "Matches your stated facts and is backed by 2 ATO source(s).",
+      "applies_because": "Applies to your structure (sole_trader). …",
+      "thresholds": [ { "name": "instant_asset_write_off", "value": 20000, "unit": "AUD", "…": "…" } ],
+      "citations": [ { "chunk_id": "…", "doc_id": "…", "title": "…", "snippet": "…", "score": 0.03 } ],
+      "…": "…"
+    }
+  ],
+  "matched_activity": { "category_id": "wre_tools_equipment", "rationale": "Activity text best matches …" },
+  "counts": { "deduction": 14, "offset": 2, "cgt_event": 2, "disallowance": 1, "precondition": 1, "strategy": 2 },
+  "notes": ["Personal services income (PSI) rules can restrict some business deductions…"],
+  "disclaimer": "This tool retrieves and structures ATO material; it is not tax advice. …"
+}
+```
+
+**Errors:** throws `Personal facts not set. Run 'ato-mcp onboard' …` when onboarding is incomplete; throws `Corpus not installed. Run 'ato-mcp update' …` when no corpus is present.
+
+## depreciation_helper
+
+Compute depreciation for a single asset across all applicable methods — prime cost, diminishing value, instant asset write-off, the $300 immediate deduction, the small business pool, and Division 43 capital works — branched by the user's taxpayer structure and small-business-entity status. Calculations are deterministic (day-count apportioned, rounded to cents); the live instant-asset-write-off threshold and ATO/legislation citations are attached per method. Methods that do not apply are listed with the reason rather than omitted.
+
+### Input
+
+| field | type | required | default | notes |
+|---|---|---|---|---|
+| `asset_cost` | number | yes | — | Must be > 0. Use the GST-exclusive cost if GST-registered. |
+| `acquisition_date` | string | yes | — | `YYYY-MM-DD`; validation error otherwise. |
+| `business_use_pct` | number | no | `100` | 0–100. Taxable-purpose proportion. |
+| `asset_type` | string | no | — | Free text; `"car"`/`"vehicle"` adds a car-limit note. |
+| `effective_life_years` | number | no | — | Must be > 0. Required for prime-cost / diminishing-value schedules; without it those methods are reported under `unavailable`. |
+| `is_small_business_entity` | boolean | no | — | Unset: SBE assumed with a confirm-eligibility note. `false`: disables IAWO and the SBE pool. |
+| `is_capital_works` | boolean | no | `false` | `true` computes the Division 43 (2.5%/40-year) schedule. |
+| `method` | string | no | `"both"` | `"prime_cost"`, `"diminishing_value"`, or `"both"` (Div 40 method selection only). |
+| `fy` | string | no | user's `current_fy` fact | `YYYY-YY`. |
+| `years` | integer | no | ceil(effective life), else 10 | 1–40. Schedule horizon. |
+
+### Output
+
+- `inputs_echo` — `{ asset_cost, acquisition_date, business_use_pct, effective_life_years, fy, asset_type }`.
+- `taxpayer_context` — `{ business_structure, is_business, is_small_business_entity }` (`null` when not provided).
+- `methods` — one entry per applicable method:
+  - `method` — `prime_cost` \| `diminishing_value` \| `instant_asset_write_off` \| `low_cost_immediate_300` \| `sbe_pool` \| `capital_works_div43`.
+  - `label`, `eligible`, `eligibility_reason` — human-readable eligibility.
+  - `first_year_deduction` — first-year claim (business-use-adjusted), or `null`.
+  - `total_base` — cost × business-use %.
+  - `schedule` — year-by-year rows `{ fy, opening_adjustable_value, decline_in_value, business_use_pct, deduction, closing_adjustable_value }`; empty for immediate write-offs.
+  - `threshold` — live threshold row (IAWO methods), or `null`.
+  - `legal_basis` — provision reference.
+  - `citations` — [Citation](#citations) array.
+  - `notes` — per-method caveats (e.g. the Div 40/Div 43 same-expenditure exclusion).
+- `unavailable` — `{ method, reason }` for every method that did not apply.
+- `recommended` — `{ method, rationale }` or `null`; immediate write-offs are preferred, and the prime-cost vs diminishing-value choice is flagged as a taxpayer election, not a recommendation.
+- `disclaimer`, `notes` — fixed disclaimer; general notes (GST-exclusive cost, car limit, second-hand rental asset restriction, citation degradation).
+
+### Example
+
+```json
+{ "asset_cost": 2800, "acquisition_date": "2025-09-15", "business_use_pct": 80, "effective_life_years": 4, "asset_type": "laptop" }
+```
+
+Response (abridged):
+
+```json
+{
+  "inputs_echo": { "asset_cost": 2800, "acquisition_date": "2025-09-15", "business_use_pct": 80, "effective_life_years": 4, "fy": "2025-26", "asset_type": "laptop" },
+  "taxpayer_context": { "business_structure": "sole_trader", "is_business": true, "is_small_business_entity": null },
+  "methods": [
+    {
+      "method": "prime_cost",
+      "eligible": true,
+      "first_year_deduction": 443.4,
+      "total_base": 2240,
+      "schedule": [ { "fy": "2025-26", "opening_adjustable_value": 2800, "decline_in_value": 554.25, "business_use_pct": 80, "deduction": 443.4, "closing_adjustable_value": 2245.75 }, "…" ],
+      "threshold": null,
+      "legal_basis": "ITAA 1997 s 40-75; s 40-25",
+      "citations": [ "…" ],
+      "notes": []
+    },
+    {
+      "method": "instant_asset_write_off",
+      "eligible": true,
+      "first_year_deduction": 2240,
+      "total_base": 2240,
+      "schedule": [],
+      "threshold": { "name": "instant_asset_write_off", "value": 20000, "unit": "AUD", "…": "…" },
+      "citations": [ "…" ],
+      "notes": ["Assumes you are a small business entity…"]
+    }
+  ],
+  "unavailable": [ { "method": "low_cost_immediate_300", "reason": "The $300 immediate deduction is for non-business depreciating assets…" }, "…" ],
+  "recommended": { "method": "instant_asset_write_off", "rationale": "Eligible for an immediate full write-off this year…" },
+  "disclaimer": "…", "notes": ["Use the GST-exclusive cost…"]
+}
+```
+
+**Errors:** throws `Personal facts not set. Run 'ato-mcp onboard' …` when onboarding is incomplete; throws `Corpus not installed. Run 'ato-mcp update' …` when no corpus is present. (A pre-9-May-2006 acquisition makes diminishing value `unavailable` — it does not throw.)
+
+## bas_prep_checklist
+
+Produce a tiered, cited BAS preparation checklist for the user's GST reporting period: which labels apply (GST G1/1A/1B, full-method G labels, PAYG withholding, PAYG instalments, FBT instalments, fuel tax credits, WET, LCT), what evidence to gather per label, and common gotchas. Sections are tiered `core` (every registered taxpayer), `confirmed` (driven by your facts, e.g. `payg_instalments`), and `conditional` (apply only if the activity exists — verify). Defaults to Simpler BAS; it does not calculate amounts. Users not registered for GST get a cited IAS or no-BAS note instead.
+
+### Input
+
+| field | type | required | default | notes |
+|---|---|---|---|---|
+| `period_type` | string | no | from the user's `gst_period` fact | `"monthly"`, `"quarterly"`, `"annual"`. |
+| `quarter` | integer | no | — | 1–4. Sets `due_date` for quarterly BAS (statutory dates). |
+| `fy` | string | no | user's `current_fy` fact | `YYYY-YY`. |
+| `full_gst_method` | boolean | no | `false` | `true` adds the full-method labels (G2, G3, G10, G11). |
+
+### Output
+
+- `registered` — whether the user is GST-registered.
+- `reporting` — `{ period_type, period_label, form, due_date, simpler_bas }`; `period_type` may be `"none"` for unregistered users, `form` is e.g. `"Quarterly BAS"` or `"Instalment activity statement (IAS)"`, `due_date` is set for quarterly periods with `quarter` given (else `null`).
+- `taxpayer_context` — `{ business_structure, gst_period, payg_instalments, fbt_payer }`.
+- `sections` — checklist sections, core first:
+  - `id`, `label` — section identity (e.g. `gst_on_sales`, "GST on sales (1A)").
+  - `tier` — `core` \| `confirmed` \| `conditional`.
+  - `applies_reason` — why it is on your checklist.
+  - `bas_labels` — the BAS label codes covered (e.g. `["1A"]`).
+  - `what_to_gather` — evidence/figures to assemble.
+  - `gotchas` — common mistakes for that label.
+  - `legal_basis` — Act reference, or `null`.
+  - `citations` — [Citation](#citations) array.
+- `not_applicable_note` — `null` when registered; otherwise the IAS / no-BAS explanation.
+- `disclaimer`, `notes` — fixed disclaimer; period guidance (Simpler BAS hint, nil-lodgment reminder, due-date notes, citation degradation).
+
+### Example
+
+```json
+{ "quarter": 2, "full_gst_method": false }
+```
+
+Response (abridged):
+
+```json
+{
+  "registered": true,
+  "reporting": { "period_type": "quarterly", "period_label": "FY2025-26 Q2", "form": "Quarterly BAS", "due_date": "2026-02-28", "simpler_bas": true },
+  "taxpayer_context": { "business_structure": "sole_trader", "gst_period": "quarterly", "payg_instalments": true, "fbt_payer": false },
+  "sections": [
+    {
+      "id": "gst_total_sales", "label": "Total sales (G1)", "tier": "core",
+      "applies_reason": "You are registered for GST.",
+      "bas_labels": ["G1"],
+      "what_to_gather": ["Total of all sales for the period…"],
+      "gotchas": ["G1 includes ALL sales, not just taxable ones.", "…"],
+      "legal_basis": "A New Tax System (GST) Act 1999",
+      "citations": [ "…" ]
+    },
+    "…"
+  ],
+  "not_applicable_note": null,
+  "disclaimer": "…",
+  "notes": ["Most small businesses use Simpler BAS…", "Lodge a 'nil' activity statement even if…"]
+}
+```
+
+**Errors:** throws `Personal facts not set. Run 'ato-mcp onboard' …` when onboarding is incomplete; throws `Corpus not installed. Run 'ato-mcp update' …` when no corpus is present.
+
+## audit_risk_check
+
+Flag patterns the ATO is known to scrutinise, given the user's facts plus an optional draft return summary (income, itemised deductions, rental figures). Runs ~13 pure rules — high work-related expenses relative to income, deductions exceeding income, round-number claims, claims hugging the $300 written-evidence concession, car claims near the cents-per-km cap, WFH + phone/internet double-claims, high clothing/laundry, self-education nexus, rental deductions with no rental income, rental interest above rental income, large repairs, crypto held but no CGT reported, and prior-year non-lodgment. Each finding carries a risk band, why it was flagged, what to do, and ATO guidance citations. It is a qualitative heuristic indicator — not an audit prediction and not numeric benchmarking.
+
+### Input
+
+| field | type | required | default | notes |
+|---|---|---|---|---|
+| `income` | number | no | — | ≥ 0. Total income in the draft return; without it the income-ratio checks are skipped. |
+| `deductions` | object[] | no | — | Items `{ category: string, amount: number ≥ 0 }`; category text is keyword-matched (e.g. "car", "working from home", "phone"). |
+| `rental` | object | no | — | `{ income?, interest?, repairs?, capital_works? }`, all ≥ 0. |
+| `business_income` | number | no | — | May be negative. |
+| `fy` | string | no | user's `current_fy` fact | `YYYY-YY`. |
+
+### Output
+
+- `fy` — financial year analysed.
+- `taxpayer_context` — `{ business_structure, occupation, has_investment_property, has_crypto }` (`occupation` nullable).
+- `summary` — `{ income, total_deductions, deduction_to_income_pct }`; `null` where not derivable from the input.
+- `findings` — fired rules, sorted high → low:
+  - `id`, `title` — rule identity (e.g. `wre_high_vs_income`).
+  - `risk_band` — `low` \| `medium` \| `high`.
+  - `pattern` — what the ATO looks for.
+  - `why_flagged` — the specific figures/facts that triggered it.
+  - `what_to_do` — substantiation/correction guidance.
+  - `legal_basis` — provision/ruling reference, or `null`.
+  - `citations` — [Citation](#citations) array.
+- `overall_risk` — the highest band among findings, or `"low"` when none fired.
+- `checked` — ids of every rule evaluated.
+- `skipped` — `{ id, reason }` for checks not assessable from the input provided (e.g. no `income` given).
+- `disclaimer`, `notes` — fixed disclaimer; heuristic/no-benchmarking caveats plus any citation-degradation note.
+
+### Example
+
+```json
+{
+  "income": 90000,
+  "deductions": [
+    { "category": "working from home", "amount": 1500 },
+    { "category": "phone and internet", "amount": 800 },
+    { "category": "car expenses", "amount": 4900 }
+  ]
+}
+```
+
+Response (abridged):
+
+```json
+{
+  "fy": "2025-26",
+  "taxpayer_context": { "business_structure": "sole_trader", "occupation": "software developer", "has_investment_property": false, "has_crypto": true },
+  "summary": { "income": 90000, "total_deductions": 7200, "deduction_to_income_pct": 8 },
+  "findings": [
+    {
+      "id": "wfh_phone_double",
+      "title": "Working-from-home and phone/internet double-claim",
+      "risk_band": "medium",
+      "why_flagged": "You have claimed both working-from-home running costs and a separate phone/internet amount — the WFH fixed rate already bundles phone and internet.",
+      "what_to_do": "If you used the WFH fixed rate, do not also claim phone and internet for the same usage.",
+      "legal_basis": "PCG 2023/1",
+      "citations": [ "…" ]
+    },
+    { "id": "crypto_unreported", "risk_band": "medium", "…": "…" },
+    { "id": "large_round_numbers", "risk_band": "medium", "…": "…" },
+    { "id": "car_near_cap", "risk_band": "low", "…": "…" }
+  ],
+  "overall_risk": "medium",
+  "checked": ["wre_high_vs_income", "deductions_exceed_income", "…"],
+  "skipped": [],
+  "disclaimer": "…",
+  "notes": ["Risk bands are heuristic indicators based on conservative thresholds…", "…"]
+}
+```
+
+**Errors:** throws `Personal facts not set. Run 'ato-mcp onboard' …` when onboarding is incomplete; throws `Corpus not installed. Run 'ato-mcp update' …` when no corpus is present.
+
+---
+
+# Disclaimers
+
+- Every workflow tool returns **structured data plus ATO citations, not tax advice**, and says so in its `disclaimer` field. Verify material decisions with a registered tax agent.
+- `audit_risk_check` risk bands and `deduction_discovery` confidence ratings are **heuristic indicators** built on conservative rules of thumb — not audit predictions, ATO determinations, or numeric benchmarking.
+- Citations resolve against the installed corpus snapshot; for time-sensitive matters check `stats.staleness_days` and confirm currency with `fetch` against the live source.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,54 +1,23 @@
 # @ato-mcp/mcp
 
-Node.js MCP server for the Australian Taxation Office corpus. v0.1 scaffolding release.
-
-## Install (development)
-
-```bash
-pnpm install
-pnpm --filter @ato-mcp/mcp build
-```
-
-## Build a local corpus
+MCP server for the Australian Taxation Office corpus — cited retrieval over 29k+ ATO
+documents, ITAA 1997, and public rulings, plus personal-context and tax workflow tools
+(`deduction_discovery`, `depreciation_helper`, `bas_prep_checklist`, `audit_risk_check`).
 
 ```bash
-cd packages/pipeline
-uv sync
-uv run ato-pipeline --out-dir corpus-out --max-total-pages 100
+npm install -g @ato-mcp/mcp
+
+# Hosted mode (no download): onboard at https://ato-mcp.com.au/onboard
+ato-mcp onboard
+
+# OR local mode (offline, ~1 GB corpus, requires zstd):
+ato-mcp update
+
+# Add to Claude Code
+claude mcp add ato-mcp -- ato-mcp mcp
 ```
 
-## Install corpus into data dir
+Full docs: https://github.com/william-laverty/ato-mcp — website: https://ato-mcp.com.au
 
-```bash
-node packages/mcp/bin/ato-mcp.js update ./packages/pipeline/corpus-out/ato.sqlite
-```
-
-## Verify
-
-```bash
-node packages/mcp/bin/ato-mcp.js stats
-```
-
-## Register with Claude Code
-
-In your Claude Code MCP config (`~/.claude/settings.json` or workspace settings):
-
-```json
-{
-  "mcpServers": {
-    "ato-mcp": {
-      "command": "node",
-      "args": ["/absolute/path/to/ato-mcp/packages/mcp/bin/ato-mcp.js", "mcp"]
-    }
-  }
-}
-```
-
-## v0.1 tools
-
-- `stats` — corpus version + counts
-- `search` — hybrid BM25 + vector retrieval
-- `get_chunks` — fetch chunks by id with neighbour context
-- `fetch` — live `ato:<path>` retrieval for pages not in the corpus
-
-See `docs/superpowers/specs/2026-05-25-ato-mcp-design.md` for the full v1 design.
+Not tax advice: tools return structured data + ATO citations for an agent to reason over.
+MIT © William Laverty

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,30 @@
 {
   "name": "@ato-mcp/mcp",
-  "version": "0.1.0",
-  "description": "MCP server for the Australian Taxation Office corpus",
+  "version": "1.0.0",
+  "description": "MCP server for the Australian Taxation Office corpus — cited tax retrieval, personal context, and workflow tools for AI agents. Local or hosted.",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "ato",
+    "australian-tax",
+    "tax",
+    "australia",
+    "claude",
+    "ai-agent",
+    "rag",
+    "itaa-1997"
+  ],
+  "license": "MIT",
+  "author": "William Laverty",
+  "homepage": "https://ato-mcp.com.au",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/william-laverty/ato-mcp.git",
+    "directory": "packages/mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/william-laverty/ato-mcp/issues"
+  },
   "type": "module",
   "bin": {
     "ato-mcp": "./bin/ato-mcp.js"
@@ -9,8 +32,15 @@
   "main": "./dist/index.js",
   "files": [
     "bin",
-    "dist"
+    "dist",
+    "README.md"
   ],
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx watch src/index.ts",

--- a/packages/mcp/src/lib/download.ts
+++ b/packages/mcp/src/lib/download.ts
@@ -9,7 +9,7 @@ import { dataDir as defaultDataDir } from "./paths.js";
 // ---------------------------------------------------------------------------
 
 const EXPECTED_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2";
-const DEFAULT_RELEASE_REPO = "williaml/ato-mcp";
+const DEFAULT_RELEASE_REPO = "william-laverty/ato-mcp";
 const CORPUS_ASSET_RE = /^ato-corpus-v.*\.sqlite\.zst$/;
 
 // ---------------------------------------------------------------------------
@@ -38,9 +38,23 @@ export interface ReleaseAssets {
   manifest: Record<string, unknown>;
 }
 
-/** Fetch the latest GitHub release and return corpus + manifest download URLs. */
+interface GithubRelease {
+  tag_name?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+  assets: Array<{ name: string; browser_download_url: string }>;
+}
+
+/**
+ * Find the newest GitHub release that actually carries a corpus asset and
+ * return corpus + manifest download URLs.
+ *
+ * Deliberately NOT `releases/latest`: this repository also publishes software
+ * releases (v1.x.x) that carry no corpus, and corpus releases must keep
+ * resolving regardless of which release is marked "latest".
+ */
 export async function fetchLatestRelease(repo: string): Promise<ReleaseAssets> {
-  const apiUrl = `https://api.github.com/repos/${repo}/releases/latest`;
+  const apiUrl = `https://api.github.com/repos/${repo}/releases?per_page=30`;
   const headers: Record<string, string> = {
     "User-Agent": "ato-mcp",
     Accept: "application/vnd.github+json",
@@ -57,25 +71,24 @@ export async function fetchLatestRelease(repo: string): Promise<ReleaseAssets> {
     throw new Error(`GitHub API returned ${resp.status} for ${apiUrl}`);
   }
 
-  const release = (await resp.json()) as {
-    assets: Array<{ name: string; browser_download_url: string }>;
-  };
-
-  const corpusAsset = release.assets.find((a) => CORPUS_ASSET_RE.test(a.name));
-  const manifestAsset = release.assets.find((a) => a.name === "manifest.json");
-
-  if (!corpusAsset) {
+  const releases = (await resp.json()) as GithubRelease[];
+  // Releases are returned newest-first; take the first non-draft release with
+  // both a corpus asset and its manifest.
+  const release = releases.find(
+    (r) =>
+      !r.draft &&
+      r.assets.some((a) => CORPUS_ASSET_RE.test(a.name)) &&
+      r.assets.some((a) => a.name === "manifest.json"),
+  );
+  if (!release) {
     throw new Error(
-      `Release is missing a corpus asset matching ${CORPUS_ASSET_RE}. ` +
-        `Found: ${release.assets.map((a) => a.name).join(", ") || "(none)"}`,
+      `No release in ${repo} contains a corpus asset matching ${CORPUS_ASSET_RE} ` +
+        `plus manifest.json. Releases seen: ${releases.map((r) => r.tag_name).join(", ") || "(none)"}`,
     );
   }
-  if (!manifestAsset) {
-    throw new Error(
-      `Release is missing manifest.json. ` +
-        `Found: ${release.assets.map((a) => a.name).join(", ") || "(none)"}`,
-    );
-  }
+
+  const corpusAsset = release.assets.find((a) => CORPUS_ASSET_RE.test(a.name))!;
+  const manifestAsset = release.assets.find((a) => a.name === "manifest.json")!;
 
   const manifestResp = await fetch(manifestAsset.browser_download_url);
   if (!manifestResp.ok) {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -269,7 +269,7 @@ export async function runMcp(): Promise<void> {
   const mode: "local" | "hosted" = cfg.mode === "hosted" ? "hosted" : "local";
 
   const server = new Server(
-    { name: "ato-mcp", version: "0.3.0" },
+    { name: "ato-mcp", version: "1.0.0" },
     { capabilities: { tools: {} } },
   );
 

--- a/packages/mcp/test/lib/download.test.ts
+++ b/packages/mcp/test/lib/download.test.ts
@@ -9,22 +9,29 @@ import { installFromLocalFile, fetchLatestRelease, runUpdateFromGitHub } from ".
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Build a minimal fake GitHub releases/latest response. */
+/** Build a minimal fake corpus release object. */
 function fakeRelease(extraAssets: Array<{ name: string; browser_download_url: string }> = []) {
   return {
-    tag_name: "v0.2.2026.05",
+    tag_name: "corpus-v2026.05",
+    draft: false,
+    prerelease: false,
     assets: [
       {
         name: "ato-corpus-v2026.05.sqlite.zst",
-        browser_download_url: "https://github.example.com/releases/download/v0.2.2026.05/ato-corpus-v2026.05.sqlite.zst",
+        browser_download_url: "https://github.example.com/releases/download/corpus-v2026.05/ato-corpus-v2026.05.sqlite.zst",
       },
       {
         name: "manifest.json",
-        browser_download_url: "https://github.example.com/releases/download/v0.2.2026.05/manifest.json",
+        browser_download_url: "https://github.example.com/releases/download/corpus-v2026.05/manifest.json",
       },
       ...extraAssets,
     ],
   };
+}
+
+/** The releases-list API returns an array, newest first. */
+function releasesList(...releases: unknown[]) {
+  return JSON.stringify(releases);
 }
 
 /** Build a manifest whose corpus_sha256 matches the provided bytes. */
@@ -79,11 +86,10 @@ describe("fetchLatestRelease", () => {
   it("returns corpus_url, manifest_url, and parsed manifest", async () => {
     const corpusBytes = new TextEncoder().encode("fake corpus data");
     const manifest = fakeManifest(corpusBytes);
-    const release = fakeRelease();
 
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce(
-        new Response(JSON.stringify(release), { status: 200, headers: { "content-type": "application/json" } }),
+        new Response(releasesList(fakeRelease()), { status: 200, headers: { "content-type": "application/json" } }),
       )
       .mockResolvedValueOnce(
         new Response(JSON.stringify(manifest), { status: 200, headers: { "content-type": "application/json" } }),
@@ -94,6 +100,28 @@ describe("fetchLatestRelease", () => {
     expect(result.manifest.embedding_model).toBe("sentence-transformers/all-MiniLM-L6-v2");
   });
 
+  it("skips newer software releases without corpus assets (regression: v1.x must not break update)", async () => {
+    const corpusBytes = new TextEncoder().encode("fake corpus data");
+    const manifest = fakeManifest(corpusBytes);
+    const softwareRelease = {
+      tag_name: "v1.0.0",
+      draft: false,
+      prerelease: false,
+      assets: [], // npm/software release — no corpus
+    };
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(releasesList(softwareRelease, fakeRelease()), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(manifest), { status: 200 }),
+      ) as unknown as typeof fetch;
+
+    const result = await fetchLatestRelease("williaml/ato-mcp");
+    expect(result.corpus_url).toContain("ato-corpus-v2026.05.sqlite.zst");
+  });
+
   it("throws on 403 with rate-limit message", async () => {
     globalThis.fetch = vi.fn().mockResolvedValueOnce(
       new Response("rate limited", { status: 403 }),
@@ -102,10 +130,11 @@ describe("fetchLatestRelease", () => {
     await expect(fetchLatestRelease("williaml/ato-mcp")).rejects.toThrow(/rate.limit/i);
   });
 
-  it("throws when corpus asset is missing", async () => {
-    const manifest = fakeManifest(new TextEncoder().encode("x"));
+  it("throws when no release carries a corpus asset", async () => {
     const releaseNoCorpus = {
-      tag_name: "v0.2.2026.05",
+      tag_name: "v1.0.0",
+      draft: false,
+      prerelease: false,
       assets: [
         {
           name: "manifest.json",
@@ -114,20 +143,18 @@ describe("fetchLatestRelease", () => {
       ],
     };
 
-    globalThis.fetch = vi.fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify(releaseNoCorpus), { status: 200 }),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify(manifest), { status: 200 }),
-      ) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(releasesList(releaseNoCorpus), { status: 200 }),
+    ) as unknown as typeof fetch;
 
-    await expect(fetchLatestRelease("williaml/ato-mcp")).rejects.toThrow(/missing a corpus asset/i);
+    await expect(fetchLatestRelease("williaml/ato-mcp")).rejects.toThrow(/no release .* corpus asset/i);
   });
 
-  it("throws when manifest.json asset is missing", async () => {
+  it("throws when the corpus release lacks manifest.json", async () => {
     const releaseNoManifest = {
-      tag_name: "v0.2.2026.05",
+      tag_name: "corpus-v2026.05",
+      draft: false,
+      prerelease: false,
       assets: [
         {
           name: "ato-corpus-v2026.05.sqlite.zst",
@@ -137,10 +164,10 @@ describe("fetchLatestRelease", () => {
     };
 
     globalThis.fetch = vi.fn().mockResolvedValueOnce(
-      new Response(JSON.stringify(releaseNoManifest), { status: 200 }),
+      new Response(releasesList(releaseNoManifest), { status: 200 }),
     ) as unknown as typeof fetch;
 
-    await expect(fetchLatestRelease("williaml/ato-mcp")).rejects.toThrow(/missing manifest/i);
+    await expect(fetchLatestRelease("williaml/ato-mcp")).rejects.toThrow(/no release .* corpus asset/i);
   });
 
   it("throws on non-200 GitHub API response", async () => {
@@ -207,7 +234,7 @@ describe("runUpdateFromGitHub", () => {
     globalThis.fetch = vi.fn()
       // 1. GitHub API
       .mockResolvedValueOnce(
-        new Response(JSON.stringify(release), { status: 200, headers: { "content-type": "application/json" } }),
+        new Response(releasesList(release), { status: 200, headers: { "content-type": "application/json" } }),
       )
       // 2. manifest.json download
       .mockResolvedValueOnce(
@@ -260,7 +287,7 @@ describe("runUpdateFromGitHub", () => {
     const release = fakeRelease();
 
     globalThis.fetch = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify(release), { status: 200 }))
+      .mockResolvedValueOnce(new Response(releasesList(release), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify(manifest), { status: 200 }))
       .mockResolvedValueOnce(
         new Response(zstBytes, { status: 200 }),
@@ -294,7 +321,7 @@ describe("runUpdateFromGitHub", () => {
     const release = fakeRelease();
 
     globalThis.fetch = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify(release), { status: 200 }))
+      .mockResolvedValueOnce(new Response(releasesList(release), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify(manifest), { status: 200 })) as unknown as typeof fetch;
 
     process.env.ATO_MCP_RELEASE_REPO = "williaml/ato-mcp";

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,11 @@
+# @ato-mcp/shared
+
+The shared tool core for [ato-mcp](https://github.com/william-laverty/ato-mcp): TypeScript
+types, Zod schemas, the `Store`/`Embedder` interfaces, and all 13 MCP tool implementations
+as pure `(deps, args) => result` functions. Consumed by `@ato-mcp/mcp` (local mode) and the
+hosted backend so both modes run identical behaviour.
+
+You probably want [`@ato-mcp/mcp`](https://www.npmjs.com/package/@ato-mcp/mcp) — this
+package is its engine.
+
+MIT © William Laverty

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@ato-mcp/shared",
-  "version": "0.1.0",
-  "private": true,
+  "version": "1.0.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -83,5 +82,34 @@
   "devDependencies": {
     "typescript": "5.6.3",
     "vitest": "2.1.5"
-  }
+  },
+  "description": "Shared tool core for ato-mcp: types, Zod schemas, Store/Embedder interfaces, and the 13 MCP tool implementations used by both local and hosted modes.",
+  "keywords": [
+    "mcp",
+    "ato",
+    "australian-tax",
+    "tax",
+    "australia"
+  ],
+  "license": "MIT",
+  "author": "William Laverty",
+  "homepage": "https://ato-mcp.com.au",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/william-laverty/ato-mcp.git",
+    "directory": "packages/shared"
+  },
+  "bugs": {
+    "url": "https://github.com/william-laverty/ato-mcp/issues"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ]
 }


### PR DESCRIPTION
## Summary
- MIT LICENSE + flagship README + CONTRIBUTING/SECURITY/CHANGELOG/RELEASING + templates
- `docs/tools.md` (complete 13-tool reference) + `docs/self-hosting.md`
- Packages → **1.0.0**, npm-publish-ready (verified via pack dry-runs); publish workflow gated on `NPM_TOKEN`
- `ato-mcp update` launch fixes: correct release repo + corpus-release selection immune to software releases (regression-tested)
- corpus-build workflow: `corpus-vYYYY.MM` tags, `--latest=false`
- CLAUDE.md refreshed for the dispatcher era; repo metadata set

## Test Plan
- [x] `pnpm -r build && pnpm -r typecheck && pnpm -r test` — **318 passing**
- [x] `npm pack --dry-run` both packages (shared 420 kB / mcp 114 kB, correct files)
- [ ] CI + preview deploys green

🤖 Generated with [Claude Code](https://claude.com/claude-code)