### PR TITLE
v1.0 website: NOX-family redesign + top-tier SEO

### DIFF
--- a/packages/pipeline/scripts/export_from_supabase.py
+++ b/packages/pipeline/scripts/export_from_supabase.py
@@ -1,0 +1,227 @@
+"""Export the hosted Supabase corpus into a local SQLite corpus file.
+
+The reverse of packages/mcp/scripts/import-corpus.ts. Used to cut a local-mode
+corpus release that is byte-identical in content to what hosted mode serves —
+useful when the source sites can't be re-scraped from the release machine
+(ato.gov.au applies aggressive bot filtering).
+
+Reads only the public-read corpus tables via PostgREST (publishable key — the
+same data any onboarded client can read), pages with keyset pagination, and
+writes the standard SQLite layout via the pipeline's own DDL so SqliteStore,
+FTS5 and sqlite-vec behave exactly as a pipeline-built corpus.
+
+Usage:
+    uv run python scripts/export_from_supabase.py \
+        --url https://<ref>.supabase.co \
+        --key sb_publishable_... \
+        --out corpus-out/ato.sqlite
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import numpy as np
+import sqlite_vec
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from ato_pipeline.package import (  # noqa: E402
+    CORPUS_SCHEMA_VERSION,
+    _SCHEMA_SQL,
+    _build_fts_table,
+    _build_vec_table,
+)
+
+PAGE = 1000
+
+
+def rest_page(client: httpx.Client, table: str, params: dict) -> list[dict]:
+    for attempt in range(5):
+        try:
+            r = client.get(f"/rest/v1/{table}", params=params)
+            r.raise_for_status()
+            return r.json()
+        except (httpx.HTTPError, json.JSONDecodeError) as e:
+            if attempt == 4:
+                raise
+            wait = 2**attempt
+            print(f"  retry {table} in {wait}s ({e})", flush=True)
+            time.sleep(wait)
+    return []
+
+
+def fetch_all(client: httpx.Client, table: str, order_col: str, select: str = "*") -> list[dict]:
+    """Offset pagination — fine for the small tables."""
+    rows: list[dict] = []
+    offset = 0
+    while True:
+        batch = rest_page(
+            client,
+            table,
+            {"select": select, "order": order_col, "limit": PAGE, "offset": offset},
+        )
+        rows.extend(batch)
+        if len(batch) < PAGE:
+            return rows
+        offset += PAGE
+
+
+def parse_vec(s: str | None) -> bytes | None:
+    if not s:
+        return None
+    return np.asarray(json.loads(s), dtype=np.float32).tobytes()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", required=True)
+    ap.add_argument("--key", required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    args = ap.parse_args()
+
+    client = httpx.Client(
+        base_url=args.url,
+        headers={"apikey": args.key, "Authorization": f"Bearer {args.key}"},
+        timeout=120,
+    )
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    if args.out.exists():
+        args.out.unlink()
+    conn = sqlite3.connect(args.out)
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    conn.executescript(_SCHEMA_SQL)
+    _build_vec_table(conn)
+    _build_fts_table(conn)
+    conn.execute(
+        "INSERT INTO meta(key, value) VALUES ('schema_version', ?)", (CORPUS_SCHEMA_VERSION,)
+    )
+
+    print("docs ...", flush=True)
+    docs = fetch_all(client, "docs", "doc_id")
+    conn.executemany(
+        "INSERT OR REPLACE INTO docs VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+        [
+            (
+                d["doc_id"], d["source"], d["url"], d["title"], d["jurisdiction"],
+                d["doc_type"], d["effective_from"], d["effective_to"], d["published_at"],
+                d["retrieved_at"], json.dumps(d.get("metadata") or {}),
+            )
+            for d in docs
+        ],
+    )
+    conn.commit()
+    print(f"  {len(docs)} docs", flush=True)
+
+    print("chunks (keyset paging) ...", flush=True)
+    n_chunks = 0
+    last_id = ""
+    while True:
+        params = {
+            "select": "chunk_id,doc_id,ord,text,heading_path,effective_from,effective_to,char_start,char_end,embedding",
+            "order": "chunk_id",
+            "limit": PAGE,
+        }
+        if last_id:
+            params["chunk_id"] = f"gt.{last_id}"
+        batch = rest_page(client, "chunks", params)
+        if not batch:
+            break
+        conn.executemany(
+            "INSERT OR REPLACE INTO chunks VALUES (?,?,?,?,?,?,?,?,?)",
+            [
+                (
+                    c["chunk_id"], c["doc_id"], c["ord"], c["text"],
+                    json.dumps(c.get("heading_path") or []),
+                    c["effective_from"], c["effective_to"],
+                    c["char_start"], c["char_end"],
+                )
+                for c in batch
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO fts_chunks(chunk_id, text) VALUES (?,?)",
+            [(c["chunk_id"], c["text"]) for c in batch],
+        )
+        vec_rows = [
+            (c["chunk_id"], parse_vec(c.get("embedding")))
+            for c in batch
+            if c.get("embedding")
+        ]
+        conn.executemany("INSERT INTO vec_chunks(chunk_id, embedding) VALUES (?,?)", vec_rows)
+        conn.commit()
+        n_chunks += len(batch)
+        last_id = batch[-1]["chunk_id"]
+        if n_chunks % 10000 < PAGE:
+            print(f"  {n_chunks} chunks ...", flush=True)
+        if len(batch) < PAGE:
+            break
+    print(f"  {n_chunks} chunks total", flush=True)
+
+    print("anchors / citations / definitions / thresholds ...", flush=True)
+    anchors = fetch_all(client, "anchors", "anchor_id")
+    conn.executemany(
+        "INSERT OR REPLACE INTO anchors VALUES (?,?,?,?)",
+        [(a["anchor_id"], a["doc_id"], a["anchor_name"], a["chunk_id"]) for a in anchors],
+    )
+    citations = fetch_all(
+        client, "citations", "id", select="from_chunk_id,to_doc_id,to_anchor,citation_kind"
+    )
+    conn.executemany(
+        "INSERT OR REPLACE INTO citations VALUES (?,?,?,?)",
+        [
+            (c["from_chunk_id"], c["to_doc_id"], c.get("to_anchor") or "", c["citation_kind"])
+            for c in citations
+        ],
+    )
+    definitions = fetch_all(
+        client, "definitions", "id",
+        select="term,doc_id,anchor_id,body,effective_from,effective_to",
+    )
+    conn.executemany(
+        "INSERT OR REPLACE INTO definitions VALUES (?,?,?,?,?,?)",
+        [
+            (d["term"], d["doc_id"], d.get("anchor_id"), d["body"], d["effective_from"], d["effective_to"])
+            for d in definitions
+        ],
+    )
+    thresholds = fetch_all(
+        client, "thresholds", "id",
+        select="name,value,unit,effective_from,effective_to,source_doc_id,source_anchor",
+    )
+    conn.executemany(
+        "INSERT OR REPLACE INTO thresholds VALUES (?,?,?,?,?,?,?)",
+        [
+            (t["name"], t["value"], t["unit"], t["effective_from"], t["effective_to"],
+             t.get("source_doc_id"), t.get("source_anchor"))
+            for t in thresholds
+        ],
+    )
+    conn.commit()
+    print(
+        f"  {len(anchors)} anchors, {len(citations)} citations, "
+        f"{len(definitions)} definitions, {len(thresholds)} thresholds",
+        flush=True,
+    )
+
+    # Sanity gates — refuse to produce a corpus that is obviously incomplete.
+    assert len(docs) > 29000, f"docs too low: {len(docs)}"
+    assert n_chunks > 220000, f"chunks too low: {n_chunks}"
+    assert len(thresholds) == 8, f"thresholds != 8: {len(thresholds)}"
+    assert len(citations) > 23000, f"citations too low: {len(citations)}"
+
+    conn.execute("VACUUM")
+    conn.close()
+    print(f"OK -> {args.out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/web/app/docs/page.tsx
+++ b/packages/web/app/docs/page.tsx
@@ -1,0 +1,158 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { TOOLS_META } from "../../lib/tools-meta";
+
+export const metadata: Metadata = {
+  title: "Documentation — install, quick start & the 13 tools",
+  description:
+    "Install ato-mcp in two minutes (hosted or fully local), connect it to Claude Code or any MCP host, and explore the 13 tools: cited ATO retrieval, personal context and tax workflows.",
+  alternates: { canonical: "/docs" },
+};
+
+const GROUPS = ["Workflows", "Retrieval", "Personal context"] as const;
+
+const docsJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  headline: "ato-mcp documentation",
+  description:
+    "Install ato-mcp, connect it to an MCP host, and use its 13 Australian-tax tools.",
+  author: { "@type": "Person", name: "William Laverty" },
+  url: "https://ato-mcp.com.au/docs",
+};
+
+export default function DocsPage() {
+  return (
+    <main className="mx-auto max-w-5xl px-5 pb-24 pt-10">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(docsJsonLd) }}
+      />
+
+      <p className="eyebrow text-brand">Documentation</p>
+      <h1 className="mt-3 max-w-2xl text-[clamp(2rem,4.4vw,3.2rem)] font-medium leading-[1.05] tracking-snugger">
+        Two minutes to <i className="font-serif italic text-brand">install</i>.
+        A career&apos;s worth of tax, on tap.
+      </h1>
+      <p className="mt-4 max-w-2xl text-[0.95rem] leading-relaxed text-ink/65">
+        ato-mcp is an MCP server: it plugs into Claude Code, Claude Desktop or any
+        Model Context Protocol host and exposes the Australian tax corpus as tools.
+        Pick a mode, connect, done.
+      </p>
+
+      {/* ----------------------------------------------- install */}
+      <section className="mt-12" aria-labelledby="install-h">
+        <h2 id="install-h" className="text-xl font-semibold tracking-snugger">1 · Install</h2>
+        <div className="mt-5 grid gap-4 md:grid-cols-2">
+          <div className="card-light dotgrid p-6">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold">Hosted <span className="ml-1 text-xs font-normal text-ink/45">recommended</span></h3>
+              <span className="rounded-full bg-brand px-2.5 py-0.5 text-[0.65rem] font-semibold uppercase tracking-caps text-white">no download</span>
+            </div>
+            <pre className="mt-4 overflow-x-auto rounded-xl bg-ink p-4 font-mono text-[0.72rem] leading-relaxed text-white/85"><code>{`npm install -g @ato-mcp/mcp
+ato-mcp onboard`}</code></pre>
+            <p className="mt-3 text-xs leading-relaxed text-ink/55">
+              Opens <Link href="/onboard" className="text-brand underline-offset-2 hover:underline">the onboarding flow</Link> —
+              magic-link sign-in, a short facts wizard, and your config is written to
+              <code className="font-mono"> ~/.ato-mcp/config.json</code> automatically.
+            </p>
+          </div>
+          <div className="card-light dotgrid p-6">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold">Local</h3>
+              <span className="rounded-full bg-ink px-2.5 py-0.5 text-[0.65rem] font-semibold uppercase tracking-caps text-white">offline</span>
+            </div>
+            <pre className="mt-4 overflow-x-auto rounded-xl bg-ink p-4 font-mono text-[0.72rem] leading-relaxed text-white/85"><code>{`npm install -g @ato-mcp/mcp
+ato-mcp update`}</code></pre>
+            <p className="mt-3 text-xs leading-relaxed text-ink/55">
+              Downloads the latest corpus release (~1 GB SQLite), verifies its sha256
+              and installs atomically. Needs Node 22+ and <code className="font-mono">zstd</code>.
+              Queries never leave your machine.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ----------------------------------------------- connect */}
+      <section className="mt-12" aria-labelledby="connect-h">
+        <h2 id="connect-h" className="text-xl font-semibold tracking-snugger">2 · Connect your agent</h2>
+        <div className="card-light mt-5 p-6">
+          <p className="text-sm font-semibold">Claude Code</p>
+          <pre className="mt-3 overflow-x-auto rounded-xl bg-ink p-4 font-mono text-[0.72rem] leading-relaxed text-white/85"><code>claude mcp add ato-mcp -- ato-mcp mcp</code></pre>
+          <p className="mt-5 text-sm font-semibold">Claude Desktop / any MCP host</p>
+          <pre className="mt-3 overflow-x-auto rounded-xl bg-ink p-4 font-mono text-[0.72rem] leading-relaxed text-white/85"><code>{`{
+  "mcpServers": {
+    "ato-mcp": { "command": "ato-mcp", "args": ["mcp"] }
+  }
+}`}</code></pre>
+          <p className="mt-4 text-xs text-ink/55">
+            Then just ask: <span className="font-serif italic">&ldquo;What can I claim as a sole-trader
+            carpenter?&rdquo;</span> — the agent calls <code className="font-mono">get_user_facts</code> once,
+            then <code className="font-mono">deduction_discovery</code>, and answers with citations.
+          </p>
+        </div>
+      </section>
+
+      {/* ----------------------------------------------- tools */}
+      <section className="mt-12" aria-labelledby="toolsref-h">
+        <h2 id="toolsref-h" className="text-xl font-semibold tracking-snugger">3 · The 13 tools</h2>
+        {GROUPS.map((g) => (
+          <div key={g} className="mt-7">
+            <p className="eyebrow text-brand">{g}</p>
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              {TOOLS_META.filter((t) => t.group === g).map((t) => (
+                <article key={t.name} className="card-light p-5">
+                  <h3 className="font-mono text-[0.82rem] font-semibold text-brand">{t.name}</h3>
+                  <p className="mt-1.5 text-sm leading-relaxed text-ink/65">{t.summary}</p>
+                  <pre className="mt-3 overflow-x-auto rounded-lg bg-ink/[0.04] px-3 py-2 font-mono text-[0.68rem] text-ink/70"><code>{t.example}</code></pre>
+                </article>
+              ))}
+            </div>
+          </div>
+        ))}
+        <p className="mt-8 text-sm text-ink/60">
+          Full input/output schemas, examples and error behaviour live in the repo:&nbsp;
+          <a
+            className="font-medium text-brand underline-offset-4 hover:underline"
+            href="https://github.com/william-laverty/ato-mcp/blob/main/docs/tools.md"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            docs/tools.md →
+          </a>
+        </p>
+      </section>
+
+      {/* ----------------------------------------------- more */}
+      <section className="mt-12 grid gap-4 md:grid-cols-3" aria-label="More resources">
+        {[
+          {
+            href: "https://github.com/william-laverty/ato-mcp",
+            title: "GitHub",
+            body: "The whole stack — server, pipeline, backend, this site — MIT licensed.",
+            ext: true,
+          },
+          {
+            href: "https://github.com/william-laverty/ato-mcp/blob/main/docs/self-hosting.md",
+            title: "Self-hosting",
+            body: "Run your own hosted stack on your own Supabase + Vercel.",
+            ext: true,
+          },
+          { href: "/privacy", title: "Privacy", body: "Schema-generated policy — see exactly what's stored.", ext: false },
+        ].map((c) =>
+          c.ext ? (
+            <a key={c.title} href={c.href} target="_blank" rel="noopener noreferrer" className="card-light dotgrid block p-5">
+              <p className="font-semibold">{c.title} ↗</p>
+              <p className="mt-1 text-sm text-ink/60">{c.body}</p>
+            </a>
+          ) : (
+            <Link key={c.title} href={c.href} className="card-light dotgrid block p-5">
+              <p className="font-semibold">{c.title}</p>
+              <p className="mt-1 text-sm text-ink/60">{c.body}</p>
+            </Link>
+          ),
+        )}
+      </section>
+    </main>
+  );
+}

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -1,3 +1,330 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ---------------------------------------------------------------------------
+   ato-mcp design system — NOX-family aesthetic.
+   Dark hero cards over layered radial meshes; light bento sections with a
+   dot-grid texture; glass pill navigation; pill CTAs with a shine sweep;
+   oversized fluid type with italic serif accents.
+--------------------------------------------------------------------------- */
+
+:root {
+  --ink: #0b0b14;
+  --paper: #f5f5f7;
+  --night: #05030f;
+  --brand: #5039bd;
+  --brand-bright: #7a5cff;
+  --brand-soft: #c794ff;
+  --ember: #ff9a3c;
+  --ease-spring: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+html {
+  scroll-behavior: smooth;
+  background-color: #ffffff;
+}
+
+body {
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+::selection {
+  background: var(--brand);
+  color: #fff;
+}
+
+/* --- Hero mesh: warm ember + cool violet radials over near-black ---------- */
+.mesh-night {
+  background-color: var(--night);
+  background-image:
+    radial-gradient(60% 50% at 12% 24%, rgba(255, 138, 60, 0.2) 0%, transparent 64%),
+    radial-gradient(52% 44% at 88% 86%, rgba(255, 160, 90, 0.14) 0%, transparent 60%),
+    radial-gradient(70% 55% at 52% 10%, rgba(122, 92, 255, 0.26) 0%, transparent 70%),
+    radial-gradient(46% 38% at 30% 78%, rgba(80, 57, 189, 0.22) 0%, transparent 66%);
+}
+
+.mesh-dark-band {
+  background-color: #07051a;
+  background-image:
+    radial-gradient(55% 60% at 80% 10%, rgba(122, 92, 255, 0.18) 0%, transparent 65%),
+    radial-gradient(50% 55% at 8% 90%, rgba(255, 138, 60, 0.1) 0%, transparent 60%);
+}
+
+/* Fine noise so the meshes never band */
+.grain::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.5;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.05 0'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* --- Dot-grid texture for light cards (masked to the lower third) -------- */
+.dotgrid {
+  position: relative;
+}
+.dotgrid::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0.05;
+  background-image: radial-gradient(rgba(0, 0, 0, 0.55) 1px, transparent 1.4px);
+  background-size: 0.8rem 0.8rem;
+  -webkit-mask-image: linear-gradient(to top, #000, transparent 72%);
+  mask-image: linear-gradient(to top, #000, transparent 72%);
+}
+
+/* --- Cards -------------------------------------------------------------- */
+.card-light {
+  background: var(--paper);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 1.1rem;
+  transition:
+    translate 0.3s var(--ease-smooth),
+    border-color 0.3s var(--ease-smooth),
+    box-shadow 0.3s var(--ease-smooth);
+}
+.card-light:hover {
+  translate: 0 -0.18rem;
+  border-color: rgba(0, 0, 0, 0.11);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.05),
+    0 6px 12px -6px rgba(0, 0, 0, 0.1),
+    0 18px 36px -18px rgba(0, 0, 0, 0.22);
+}
+
+.card-night {
+  background: rgba(10, 7, 30, 0.78);
+  border: 1px solid rgba(199, 148, 255, 0.16);
+  border-radius: 1.1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(14px);
+  transition:
+    translate 0.3s var(--ease-smooth),
+    border-color 0.3s var(--ease-smooth),
+    box-shadow 0.3s var(--ease-smooth);
+}
+.card-night:hover {
+  translate: 0 -0.18rem;
+  border-color: rgba(199, 148, 255, 0.34);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.4),
+    0 2px 8px rgba(216, 205, 247, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+/* --- Pill buttons with shine sweep --------------------------------------- */
+.btn {
+  position: relative;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition:
+    transform 0.3s var(--ease-smooth),
+    box-shadow 0.3s var(--ease-smooth),
+    background-color 0.3s var(--ease-smooth),
+    border-color 0.3s var(--ease-smooth);
+}
+.btn:hover {
+  transform: translateY(-1px);
+}
+.btn:active {
+  transform: translateY(0);
+}
+.btn::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -120%;
+  height: 100%;
+  width: 60%;
+  transform: skewX(-18deg);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.28), transparent);
+  transition: none;
+}
+.btn:hover::after {
+  animation: btnShine 1.1s var(--ease-smooth);
+}
+@keyframes btnShine {
+  from { left: -120%; }
+  to { left: 160%; }
+}
+
+.btn-solid {
+  background: linear-gradient(180deg, #6a4fe8 0%, var(--brand) 100%);
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(33, 4, 104, 0.35);
+}
+.btn-solid:hover {
+  box-shadow: 0 12px 28px rgba(33, 4, 104, 0.45);
+}
+
+.btn-ghost-dark {
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  color: #f4f2f7;
+  background: rgba(255, 255, 255, 0.04);
+}
+.btn-ghost-dark:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+.btn-ghost-light {
+  border: 1px solid rgba(11, 11, 20, 0.16);
+  color: var(--ink);
+  background: #fff;
+}
+.btn-ghost-light:hover {
+  border-color: rgba(11, 11, 20, 0.34);
+}
+
+/* --- Micro label (uppercase eyebrow) ------------------------------------- */
+.eyebrow {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+/* --- Gradient number / text ---------------------------------------------- */
+.grad-text {
+  background: linear-gradient(180deg, #1d1d1f 0%, var(--brand) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.grad-text-night {
+  background: linear-gradient(180deg, #f4f2f7 10%, var(--brand-soft) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+/* --- Entrance reveals (staggered via --reveal-delay) ---------------------- */
+@keyframes revealUp {
+  from {
+    opacity: 0;
+    transform: translateY(22px);
+    filter: blur(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+.reveal {
+  animation: revealUp 0.8s var(--ease-spring) both;
+  animation-delay: var(--reveal-delay, 0s);
+}
+
+/* Scroll-triggered reveals for below-the-fold sections (no JS) */
+@supports (animation-timeline: view()) {
+  .reveal-scroll {
+    animation: revealUp 0.9s var(--ease-spring) both;
+    animation-timeline: view();
+    animation-range: entry 0% entry 38%;
+  }
+}
+
+/* --- Citation chips ------------------------------------------------------- */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(199, 148, 255, 0.3);
+  background: rgba(122, 92, 255, 0.12);
+  color: #d8cdf7;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+.chip-dot {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 9999px;
+  background: var(--brand-soft);
+  box-shadow: 0 0 8px rgba(199, 148, 255, 0.9);
+}
+
+/* --- Marquee ---------------------------------------------------------------
+   The track holds two copies of the chip row; translating -50% loops it. */
+.marquee {
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 12%, #000 88%, transparent);
+  mask-image: linear-gradient(90deg, transparent, #000 12%, #000 88%, transparent);
+}
+.marquee-track {
+  display: flex;
+  width: max-content;
+  gap: 0.75rem;
+}
+.marquee:hover .marquee-track {
+  animation-play-state: paused;
+}
+
+/* --- Terminal mock -------------------------------------------------------- */
+.term {
+  background: rgba(5, 3, 15, 0.9);
+  border: 1px solid rgba(199, 148, 255, 0.22);
+  border-radius: 1rem;
+  box-shadow:
+    0 24px 60px -24px rgba(0, 0, 0, 0.7),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07);
+}
+.term-cursor::after {
+  content: "▋";
+  margin-left: 2px;
+  color: var(--brand-soft);
+  animation: blink 1.1s steps(1) infinite;
+}
+@keyframes blink {
+  50% { opacity: 0; }
+}
+
+/* --- Footer wordmark ------------------------------------------------------ */
+.wordmark {
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 0.82;
+  background: linear-gradient(180deg, rgba(244, 242, 247, 0.22) 0%, rgba(244, 242, 247, 0.05) 90%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  user-select: none;
+}
+
+/* --- Reduced motion -------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  .reveal,
+  .reveal-scroll,
+  .btn::after,
+  .term-cursor::after {
+    animation: none !important;
+  }
+  .marquee-track {
+    animation: none !important;
+  }
+  .card-light:hover,
+  .card-night:hover,
+  .btn:hover {
+    translate: none;
+    transform: none;
+  }
+}

--- a/packages/web/app/icon.svg
+++ b/packages/web/app/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 32 32" fill="none">
+  <rect x="1" y="1" width="30" height="30" rx="9" fill="#5039bd"/>
+  <circle cx="12" cy="16" r="3.4" fill="#f4f2f7"/>
+  <circle cx="22" cy="10" r="2.5" fill="#c794ff"/>
+  <circle cx="22" cy="22" r="2.5" fill="#ff9a3c"/>
+  <path d="M14.9 14.4l4.6-3.2M14.9 17.6l4.6 3.2" stroke="#f4f2f7" stroke-width="1.7"/>
+</svg>

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,11 +1,98 @@
 import type { Metadata } from "next";
+import { Hanken_Grotesk, Instrument_Serif, IBM_Plex_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
+import { Nav } from "../components/site/Nav";
+import { Footer } from "../components/site/Footer";
 import "./globals.css";
 
+const sans = Hanken_Grotesk({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-sans",
+  display: "swap",
+});
+
+const serif = Instrument_Serif({
+  subsets: ["latin"],
+  weight: "400",
+  style: ["normal", "italic"],
+  variable: "--font-serif",
+  display: "swap",
+});
+
+const mono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  variable: "--font-mono",
+  display: "swap",
+});
+
+const SITE = "https://ato-mcp.com.au";
+
 export const metadata: Metadata = {
-  title: "ato-mcp.com.au — Australian tax retrieval for AI agents",
+  metadataBase: new URL(SITE),
+  title: {
+    default: "ato-mcp — The Australian tax knowledge base for AI agents",
+    template: "%s · ato-mcp",
+  },
   description:
-    "Connect your AI agent to the Australian Taxation Office knowledge base. Search legislation, rulings, and determinations via MCP.",
+    "Give Claude and any MCP agent cited, current retrieval over 29,000+ ATO documents, ITAA 1997 and public rulings — plus personal context and four tax workflow tools. Local or hosted. Open source.",
+  keywords: [
+    "ATO MCP server",
+    "Australian tax AI",
+    "Model Context Protocol",
+    "Claude tax tools",
+    "ATO API for AI agents",
+    "ITAA 1997 search",
+    "Australian tax deductions AI",
+    "BAS checklist AI",
+    "tax RAG Australia",
+  ],
+  authors: [{ name: "William Laverty", url: "https://github.com/william-laverty" }],
+  creator: "William Laverty",
+  alternates: { canonical: "/" },
+  openGraph: {
+    type: "website",
+    locale: "en_AU",
+    url: SITE,
+    siteName: "ato-mcp",
+    title: "ato-mcp — The Australian tax knowledge base for AI agents",
+    description:
+      "Cited retrieval over 29,000+ ATO documents, ITAA 1997 and rulings, with personal context and tax workflow tools for AI agents. Local or hosted. Open source.",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "ato-mcp — The Australian tax knowledge base for AI agents",
+    description:
+      "Cited ATO retrieval + tax workflow tools for AI agents over the Model Context Protocol. Local or hosted. Open source.",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: { index: true, follow: true, "max-image-preview": "large" },
+  },
+};
+
+const orgJsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": `${SITE}/#org`,
+      name: "ato-mcp",
+      url: SITE,
+      logo: `${SITE}/icon.svg`,
+      sameAs: ["https://github.com/william-laverty/ato-mcp"],
+    },
+    {
+      "@type": "WebSite",
+      "@id": `${SITE}/#website`,
+      url: SITE,
+      name: "ato-mcp",
+      publisher: { "@id": `${SITE}/#org` },
+      inLanguage: "en-AU",
+    },
+  ],
 };
 
 export default function RootLayout({
@@ -14,9 +101,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body className="min-h-screen bg-white text-gray-900 antialiased">
-        {children}
+    <html lang="en-AU" className={`${sans.variable} ${serif.variable} ${mono.variable}`}>
+      <body className="min-h-screen bg-white font-sans text-ink antialiased">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}
+        />
+        <Nav />
+        <div className="pt-[4.2rem]">{children}</div>
+        <Footer />
         <Analytics />
       </body>
     </html>

--- a/packages/web/app/not-found.tsx
+++ b/packages/web/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="px-3 pb-4 pt-2 sm:px-4">
+      <div className="mesh-night grain relative flex min-h-[70vh] items-center justify-center overflow-hidden rounded-[1.6rem] px-6 text-center">
+        <div className="relative z-10">
+          <p className="font-mono text-[0.78rem] text-ember">404 · not assessable</p>
+          <h1 className="mt-4 text-[clamp(2rem,5vw,3.4rem)] font-medium tracking-snugger text-[#f4f2f7]">
+            This page is <i className="font-serif italic text-brand-soft">not deductible</i>.
+          </h1>
+          <p className="mx-auto mt-4 max-w-md text-sm text-white/65">
+            Whatever you were looking for isn&apos;t in the corpus. Try the docs, or head home.
+          </p>
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+            <Link href="/" className="btn btn-solid px-6 py-3 text-sm">Back home</Link>
+            <Link href="/docs" className="btn btn-ghost-dark px-6 py-3 text-sm">Read the docs</Link>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/packages/web/app/opengraph-image.tsx
+++ b/packages/web/app/opengraph-image.tsx
@@ -1,0 +1,90 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "ato-mcp — The Australian tax knowledge base for AI agents";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: 72,
+          backgroundColor: "#05030f",
+          backgroundImage:
+            "radial-gradient(60% 50% at 12% 24%, rgba(255,138,60,0.22) 0%, transparent 64%)," +
+            "radial-gradient(70% 55% at 55% 0%, rgba(122,92,255,0.3) 0%, transparent 70%)," +
+            "radial-gradient(46% 38% at 85% 90%, rgba(80,57,189,0.28) 0%, transparent 66%)",
+          color: "#f4f2f7",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+          <div
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: 16,
+              backgroundColor: "#5039bd",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 30,
+              color: "#f4f2f7",
+            }}
+          >
+            ◈
+          </div>
+          <div style={{ fontSize: 34, fontWeight: 700, letterSpacing: -1 }}>ato-mcp</div>
+          <div
+            style={{
+              marginLeft: 8,
+              fontSize: 18,
+              color: "rgba(244,242,247,0.65)",
+              border: "1px solid rgba(255,255,255,0.2)",
+              borderRadius: 999,
+              padding: "6px 16px",
+            }}
+          >
+            v1.0 · open source
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 22 }}>
+          <div style={{ fontSize: 64, fontWeight: 600, letterSpacing: -2, lineHeight: 1.05, maxWidth: 980 }}>
+            Your AI agent just became fluent in Australian tax.
+          </div>
+          <div style={{ fontSize: 26, color: "rgba(244,242,247,0.7)", maxWidth: 900 }}>
+            Cited retrieval over 29,000+ ATO documents, ITAA 1997 & rulings — plus tax
+            workflow tools that know your situation. Local or hosted.
+          </div>
+        </div>
+
+        <div style={{ display: "flex", gap: 12 }}>
+          {["ITAA 1997 · s 8-1", "TR 97/12", "PCG 2023/1", "Div 40", "GSTR 2000/27"].map((c) => (
+            <div
+              key={c}
+              style={{
+                fontSize: 18,
+                color: "#d8cdf7",
+                backgroundColor: "rgba(122,92,255,0.14)",
+                border: "1px solid rgba(199,148,255,0.35)",
+                borderRadius: 999,
+                padding: "8px 18px",
+              }}
+            >
+              {c}
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,60 +1,376 @@
+import type { Metadata } from "next";
 import Link from "next/link";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/" },
+};
+
+/* ---------------------------------------------------------------------------
+   Landing page. Dark hero card over a layered radial mesh, an agent-answer
+   terminal with live-looking citations, light bento corpus stats, the four
+   workflow tools, modes, privacy and FAQ. All motion is CSS-only.
+--------------------------------------------------------------------------- */
+
+const RULING_CHIPS = [
+  "ITAA 1997 · s 8-1", "TR 97/12", "PCG 2023/1", "GSTR 2000/27", "Div 40",
+  "TD 2024/3", "ITAA 1997 · s 40-25", "LCR 2019/1", "Div 328", "TR 2026/1",
+  "MT 2027", "ITAA 1997 · Div 30", "GSTD 2014/3", "TR 2021/4", "Div 43",
+  "CR 2018/37", "ITAA 1997 · s 25-10", "FTR 2012/1", "PR 2006/114", "Div 35",
+];
+
+const STATS = [
+  { n: "29,181", label: "documents", sub: "ato.gov.au · legislation · rulings" },
+  { n: "224,585", label: "chunks", sub: "hybrid BM25 + vector indexed" },
+  { n: "4,638", label: "ITAA 1997 sections", sub: "+ 1,929 statutory definitions" },
+  { n: "2,127", label: "public rulings", sub: "typed across 10 ruling series" },
+  { n: "23,267", label: "citation edges", sub: "rulings ⇄ legislation graph" },
+  { n: "13", label: "MCP tools", sub: "retrieval · context · workflows" },
+];
+
+const WORKFLOWS = [
+  {
+    name: "deduction_discovery",
+    title: "Every deduction that fits your shape",
+    body: "A 59-category curated taxonomy filtered by your facts — sole trader, company, trust, partnership, investor or SMSF member — each category cited and confidence-rated.",
+  },
+  {
+    name: "depreciation_helper",
+    title: "Depreciation, computed not guessed",
+    body: "Prime cost vs diminishing value vs instant write-off vs small-business pool vs Div 43 — deterministic year-by-year schedules with the live IAWO threshold.",
+  },
+  {
+    name: "bas_prep_checklist",
+    title: "BAS prep without the scramble",
+    body: "A tiered checklist for your reporting period: which labels apply, what evidence to gather, the gotchas — every section backed by ATO guidance.",
+  },
+  {
+    name: "audit_risk_check",
+    title: "Know what the ATO looks at",
+    body: "Heuristic red-flags over a draft return — WRE vs income, rental anomalies, unreported crypto — each with a risk band and the guidance behind it.",
+  },
+];
+
+const FAQS = [
+  {
+    q: "Is this tax advice?",
+    a: "No. ato-mcp is information infrastructure: it retrieves and structures published ATO material and computes deterministic schedules, always with citations. Confidence ratings and risk bands are heuristic indicators. Your agent does the reasoning, and material decisions should be verified with a registered tax agent.",
+  },
+  {
+    q: "What's the difference between local and hosted mode?",
+    a: "Local mode downloads a ~1 GB SQLite corpus and runs everything — including embeddings — on your machine; queries never leave your device. Hosted mode skips the download and queries api.ato-mcp.com.au over TLS with a personal bearer token. Both run the identical open-source tool code against the identical corpus snapshot.",
+  },
+  {
+    q: "What does hosted mode store about me?",
+    a: "Your onboarding facts (business structure, GST registration, and so on — about 25 fields you control), a hashed bearer token, and coarse usage events. Never tool names, never query content, never results: the schema physically has nowhere to store them, and the privacy page is generated from that schema so it can't drift.",
+  },
+  {
+    q: "Which agents does it work with?",
+    a: "Anything that speaks the Model Context Protocol over stdio — Claude Code and Claude Desktop most prominently, plus any other MCP-capable host. One config line after onboarding.",
+  },
+  {
+    q: "How current is the corpus?",
+    a: "The corpus is rebuilt from ato.gov.au, the Federal Register of Legislation and law.ato.gov.au on a monthly cycle, and every release is sha256-verified on install. The stats tool reports the installed snapshot and flags staleness.",
+  },
+  {
+    q: "Is it really open source?",
+    a: "MIT licensed, end to end — the MCP server, the corpus pipeline, the hosted backend and this website are all in the same public repository. For a tool that reads tax law to you, verifiability is the point.",
+  },
+];
+
+const SITE = "https://ato-mcp.com.au";
+
+const pageJsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "SoftwareApplication",
+      name: "ato-mcp",
+      operatingSystem: "macOS, Linux, Windows",
+      applicationCategory: "DeveloperApplication",
+      description:
+        "MCP server giving AI agents cited retrieval over 29,000+ ATO documents, ITAA 1997 and public rulings, with personal context and four tax workflow tools.",
+      url: SITE,
+      downloadUrl: "https://www.npmjs.com/package/@ato-mcp/mcp",
+      softwareVersion: "1.0.0",
+      offers: { "@type": "Offer", price: "0", priceCurrency: "AUD" },
+      license: "https://github.com/william-laverty/ato-mcp/blob/main/LICENSE",
+    },
+    {
+      "@type": "FAQPage",
+      mainEntity: FAQS.map((f) => ({
+        "@type": "Question",
+        name: f.q,
+        acceptedAnswer: { "@type": "Answer", text: f.a },
+      })),
+    },
+  ],
+};
+
+function HeroTerminal() {
+  return (
+    <div className="term reveal p-5 text-left font-mono text-[0.78rem] leading-relaxed sm:p-6" style={{ "--reveal-delay": "0.45s" } as React.CSSProperties}>
+      <div className="mb-4 flex items-center gap-1.5" aria-hidden="true">
+        <span className="h-2.5 w-2.5 rounded-full bg-white/15" />
+        <span className="h-2.5 w-2.5 rounded-full bg-white/15" />
+        <span className="h-2.5 w-2.5 rounded-full bg-white/15" />
+        <span className="ml-3 text-[0.68rem] tracking-wide text-white/30">claude · ato-mcp connected</span>
+      </div>
+      <p className="text-white/55">
+        <span className="text-ember">›</span> can I claim my home office as a sole trader?
+      </p>
+      <p className="mt-3 text-white/85">
+        Yes — running expenses are deductible, and because part of your home is a
+        genuine place of business you may also claim occupancy costs (with a CGT
+        trade-off worth knowing about). Two methods apply:
+      </p>
+      <p className="mt-2 text-white/70">
+        — fixed-rate <span className="text-brand-soft">(PCG 2023/1)</span>: cents per hour, bundles energy, phone &amp; internet
+        <br />— actual cost <span className="text-brand-soft">(TR 93/30)</span>: work-share of real running costs
+      </p>
+      <div className="mt-4 flex flex-wrap gap-2" aria-label="Citations">
+        <span className="chip"><span className="chip-dot" />ITAA 1997 · s 8-1</span>
+        <span className="chip"><span className="chip-dot" />PCG 2023/1</span>
+        <span className="chip"><span className="chip-dot" />TR 93/30</span>
+        <span className="chip"><span className="chip-dot" />Home-based business expenses</span>
+      </div>
+      <p className="term-cursor mt-4 text-white/40">resolved 4 citations · deduction_discovery → 32 categories for your profile</p>
+    </div>
+  );
+}
 
 export default function HomePage() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center px-4">
-      <div className="max-w-2xl w-full text-center space-y-8">
-        <div className="space-y-4">
-          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-            ato-mcp.com
-          </h1>
-          <p className="text-xl text-gray-600">
-            Australian tax retrieval for AI agents
-          </p>
-          <p className="text-base text-gray-500 max-w-lg mx-auto">
-            Give your AI assistant direct access to ATO legislation, rulings,
-            and determinations via the Model Context Protocol.
-          </p>
-        </div>
+    <main>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(pageJsonLd) }}
+      />
 
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Link
-            href="/onboard"
-            className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-6 py-3 text-base font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 transition-colors"
-          >
-            Get started
+      {/* ------------------------------------------------ hero */}
+      <section className="px-3 pt-2 sm:px-4">
+        <div className="mesh-night grain relative overflow-hidden rounded-[1.6rem] px-5 pb-12 pt-16 sm:px-10 sm:pb-16 sm:pt-24">
+          <div className="relative z-10 mx-auto max-w-6xl">
+            <div className="grid items-center gap-10 lg:grid-cols-[1.05fr_0.95fr]">
+              <div>
+                <p className="reveal inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.06] px-3.5 py-1.5 text-[0.7rem] font-medium tracking-wide text-white/75" style={{ "--reveal-delay": "0s" } as React.CSSProperties}>
+                  <span className="inline-block h-1.5 w-1.5 rounded-full bg-ember shadow-[0_0_8px_rgba(255,154,60,0.9)]" />
+                  v1.0 · open source · MIT
+                </p>
+                <h1 className="reveal mt-6 text-[clamp(2.4rem,5.4vw,4.1rem)] font-medium leading-[1.02] tracking-snugger text-[#f4f2f7]" style={{ "--reveal-delay": "0.1s" } as React.CSSProperties}>
+                  Your AI agent just became{" "}
+                  <i className="font-serif italic text-brand-soft">fluent</i> in
+                  Australian tax<span className="text-ember">.</span>
+                </h1>
+                <p className="reveal mt-5 max-w-xl text-[0.98rem] leading-relaxed text-white/75" style={{ "--reveal-delay": "0.22s" } as React.CSSProperties}>
+                  ato-mcp gives Claude — and any MCP agent — cited, current retrieval
+                  over 29,000+ ATO documents, the ITAA 1997 and 2,127 public rulings,
+                  plus workflow tools that already know your taxpayer shape.
+                  Answers come with the section, the ruling and the page. Not vibes.
+                </p>
+                <div className="reveal mt-8 flex flex-wrap items-center gap-3" style={{ "--reveal-delay": "0.34s" } as React.CSSProperties}>
+                  <Link href="/onboard" className="btn btn-solid px-6 py-3 text-sm">
+                    Get started free
+                  </Link>
+                  <Link href="/docs" className="btn btn-ghost-dark px-6 py-3 text-sm">
+                    Read the docs
+                  </Link>
+                </div>
+                <p className="reveal mt-5 font-mono text-[0.72rem] text-white/40" style={{ "--reveal-delay": "0.4s" } as React.CSSProperties}>
+                  npm i -g @ato-mcp/mcp · works with Claude Code, Claude Desktop &amp; any MCP host
+                </p>
+              </div>
+              <HeroTerminal />
+            </div>
+
+            {/* ruling marquee */}
+            <div className="marquee mt-14" aria-hidden="true">
+              <div className="marquee-track animate-chipMarquee">
+                {[...RULING_CHIPS, ...RULING_CHIPS].map((c, i) => (
+                  <span key={i} className="whitespace-nowrap rounded-full border border-white/10 px-3.5 py-1.5 font-mono text-[0.68rem] text-white/45">
+                    {c}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ------------------------------------------------ corpus bento */}
+      <section className="mx-auto max-w-6xl px-5 py-20 sm:py-28" aria-labelledby="corpus-h">
+        <p className="eyebrow text-brand">The corpus</p>
+        <h2 id="corpus-h" className="mt-3 max-w-2xl text-[clamp(1.7rem,3.4vw,2.6rem)] font-medium leading-tight tracking-snugger">
+          The whole landscape, <i className="font-serif italic text-brand">indexed</i> —
+          guidance, statute and rulings in one graph.
+        </h2>
+        <div className="mt-10 grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-3">
+          {STATS.map((s) => (
+            <div key={s.label} className="card-light dotgrid reveal-scroll p-5 sm:p-6">
+              <p className="grad-text text-[clamp(1.8rem,3.6vw,2.8rem)] font-bold tracking-snugger">{s.n}</p>
+              <p className="mt-1 text-sm font-semibold">{s.label}</p>
+              <p className="mt-1 text-xs text-ink/50">{s.sub}</p>
+            </div>
+          ))}
+        </div>
+        <p className="mt-6 text-sm text-ink/55">
+          Rebuilt monthly. Point-in-time aware. Every release sha256-verified.{" "}
+          <Link href="/docs" className="font-medium text-brand underline-offset-4 hover:underline">
+            See what&apos;s inside →
           </Link>
-          <a
-            href="https://github.com/ato-mcp"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center justify-center rounded-lg border border-gray-300 bg-white px-6 py-3 text-base font-semibold text-gray-700 shadow-sm hover:bg-gray-50 transition-colors"
-          >
-            View on GitHub
-          </a>
-        </div>
+        </p>
+      </section>
 
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 pt-8 border-t border-gray-100">
-          <div className="text-left space-y-2">
-            <h3 className="font-semibold text-gray-900">MCP Native</h3>
-            <p className="text-sm text-gray-500">
-              Works with Claude, Cursor, and any MCP-compatible AI client.
+      {/* ------------------------------------------------ workflows */}
+      <section id="tools" className="px-3 sm:px-4" aria-labelledby="tools-h">
+        <div className="mesh-dark-band grain relative overflow-hidden rounded-[1.6rem] px-5 py-20 sm:px-10 sm:py-24">
+          <div className="relative z-10 mx-auto max-w-6xl">
+            <p className="eyebrow text-brand-soft">Workflow tools</p>
+            <h2 id="tools-h" className="mt-3 max-w-2xl text-[clamp(1.7rem,3.4vw,2.6rem)] font-medium leading-tight tracking-snugger text-[#f4f2f7]">
+              Not a search box. <i className="font-serif italic text-brand-soft">Workflows</i>{" "}
+              that know who&apos;s asking.
+            </h2>
+            <p className="mt-4 max-w-2xl text-[0.95rem] leading-relaxed text-white/65">
+              Onboard once — business structure, GST status, investments, super — and
+              the four hero tools branch for your exact taxpayer shape. Every output is
+              structured data plus resolvable ATO citations: your agent reasons, you verify.
             </p>
-          </div>
-          <div className="text-left space-y-2">
-            <h3 className="font-semibold text-gray-900">ATO Corpus</h3>
-            <p className="text-sm text-gray-500">
-              Searches legislation, tax rulings, and ATO determinations.
-            </p>
-          </div>
-          <div className="text-left space-y-2">
-            <h3 className="font-semibold text-gray-900">Personal Context</h3>
-            <p className="text-sm text-gray-500">
-              Optionally store your tax situation for tailored responses.
-            </p>
+            <div className="mt-10 grid gap-4 md:grid-cols-2">
+              {WORKFLOWS.map((w) => (
+                <article key={w.name} className="card-night reveal-scroll p-6">
+                  <p className="font-mono text-[0.72rem] text-ember">{w.name}</p>
+                  <h3 className="mt-2 text-lg font-semibold text-[#f4f2f7]">{w.title}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-white/65">{w.body}</p>
+                </article>
+              ))}
+            </div>
+            <div className="mt-10 rounded-2xl border border-white/10 bg-white/[0.04] p-5">
+              <p className="eyebrow text-white/40">Plus the retrieval layer</p>
+              <p className="mt-2.5 font-mono text-[0.78rem] leading-loose text-white/60">
+                search · get_chunks · get_doc · get_doc_anchors · get_definition ·
+                get_threshold · fetch · stats · get_user_facts
+              </p>
+              <p className="mt-2 text-sm text-white/55">
+                Hybrid BM25 + vector search, a 23,267-edge citation graph, statutory
+                definitions and time-keyed thresholds — the substrate the workflows stand on.{" "}
+                <Link href="/docs" className="font-medium text-brand-soft underline-offset-4 hover:underline">
+                  Full tool reference →
+                </Link>
+              </p>
+            </div>
           </div>
         </div>
-      </div>
+      </section>
+
+      {/* ------------------------------------------------ modes */}
+      <section id="modes" className="mx-auto max-w-6xl px-5 py-20 sm:py-28" aria-labelledby="modes-h">
+        <p className="eyebrow text-brand">Two ways to run it</p>
+        <h2 id="modes-h" className="mt-3 max-w-2xl text-[clamp(1.7rem,3.4vw,2.6rem)] font-medium leading-tight tracking-snugger">
+          Your tax data, <i className="font-serif italic text-brand">your terms</i>.
+        </h2>
+        <div className="mt-10 grid gap-4 md:grid-cols-2">
+          <div className="card-light dotgrid reveal-scroll p-7">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xl font-semibold">Local</h3>
+              <span className="rounded-full bg-ink px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-caps text-white">offline</span>
+            </div>
+            <p className="mt-3 text-sm leading-relaxed text-ink/65">
+              A ~1 GB SQLite corpus on your disk, embeddings via ONNX on your CPU.
+              Queries never leave the machine — there is nothing to trust because
+              nothing is sent.
+            </p>
+            <pre className="mt-5 overflow-x-auto rounded-xl bg-ink p-4 font-mono text-[0.72rem] leading-relaxed text-white/85"><code>{`npm install -g @ato-mcp/mcp
+ato-mcp update   # download + verify corpus
+claude mcp add ato-mcp -- ato-mcp mcp`}</code></pre>
+            <p className="mt-3 text-xs text-ink/45">Free forever · monthly corpus releases · sha256-verified</p>
+          </div>
+          <div className="card-light dotgrid reveal-scroll p-7">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xl font-semibold">Hosted</h3>
+              <span className="rounded-full bg-brand px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-caps text-white">zero download</span>
+            </div>
+            <p className="mt-3 text-sm leading-relaxed text-ink/65">
+              Same tools, served from api.ato-mcp.com.au over TLS with a personal
+              bearer token. Always the freshest corpus; tool calls are never logged —
+              and the server code is open source, so you can check.
+            </p>
+            <pre className="mt-5 overflow-x-auto rounded-xl bg-ink p-4 font-mono text-[0.72rem] leading-relaxed text-white/85"><code>{`npm install -g @ato-mcp/mcp
+ato-mcp onboard  # browser onboarding, ~2 min
+claude mcp add ato-mcp -- ato-mcp mcp`}</code></pre>
+            <p className="mt-3 text-xs text-ink/45">Magic-link sign-in · revocable tokens · row-level security</p>
+          </div>
+        </div>
+        <p className="mt-6 text-sm text-ink/55">
+          Both modes run the <span className="font-medium text-ink">identical shared tool core</span> —
+          behaviour can&apos;t drift between them, because it&apos;s the same code.
+        </p>
+      </section>
+
+      {/* ------------------------------------------------ privacy strip */}
+      <section className="mx-auto max-w-6xl px-5 pb-20 sm:pb-28" aria-labelledby="privacy-h">
+        <div className="card-light relative overflow-hidden p-8 sm:p-10">
+          <div className="max-w-3xl">
+            <p className="eyebrow text-brand">Privacy, by construction</p>
+            <h2 id="privacy-h" className="mt-3 text-[clamp(1.4rem,2.6vw,2rem)] font-medium leading-tight tracking-snugger">
+              The privacy policy is <i className="font-serif italic text-brand">generated from the database schema</i> —
+              so it can&apos;t lie.
+            </h2>
+            <p className="mt-4 text-sm leading-relaxed text-ink/65">
+              Hosted mode has no table for queries, tool calls or results — the data
+              model physically can&apos;t retain them. The privacy page renders every stored
+              field straight from the schema, and a contract test fails the build if a
+              field goes undocumented. Personal rows are isolated with Postgres
+              row-level security, and one button deletes everything.
+            </p>
+            <Link href="/privacy" className="btn btn-ghost-light mt-6 px-5 py-2.5 text-sm">
+              Read the privacy policy
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ------------------------------------------------ FAQ */}
+      <section className="mx-auto max-w-3xl px-5 pb-24" aria-labelledby="faq-h">
+        <p className="eyebrow text-center text-brand">FAQ</p>
+        <h2 id="faq-h" className="mt-3 text-center text-[clamp(1.7rem,3.2vw,2.4rem)] font-medium tracking-snugger">
+          The questions that <i className="font-serif italic text-brand">matter</i>.
+        </h2>
+        <div className="mt-10 space-y-3">
+          {FAQS.map((f) => (
+            <details key={f.q} className="group rounded-2xl border border-black/[0.07] bg-paper px-6 py-4 open:bg-white open:shadow-sm">
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-4 text-[0.95rem] font-semibold marker:hidden">
+                {f.q}
+                <span className="text-lg text-brand transition-transform duration-300 group-open:rotate-45" aria-hidden="true">+</span>
+              </summary>
+              <p className="mt-3 text-sm leading-relaxed text-ink/65">{f.a}</p>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      {/* ------------------------------------------------ final CTA */}
+      <section className="px-3 pb-4 sm:px-4">
+        <div className="mesh-night grain relative overflow-hidden rounded-[1.6rem] px-6 py-20 text-center sm:py-24">
+          <div className="relative z-10 mx-auto max-w-2xl">
+            <h2 className="text-[clamp(1.9rem,4vw,3rem)] font-medium leading-tight tracking-snugger text-[#f4f2f7]">
+              Two minutes to a <i className="font-serif italic text-brand-soft">tax-fluent</i> agent.
+            </h2>
+            <p className="mt-4 text-[0.95rem] text-white/65">
+              Onboard, paste one config line, ask better questions.
+            </p>
+            <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+              <Link href="/onboard" className="btn btn-solid px-7 py-3 text-sm">Get started free</Link>
+              <a
+                href="https://github.com/william-laverty/ato-mcp"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-ghost-dark px-7 py-3 text-sm"
+              >
+                Star on GitHub
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
     </main>
   );
 }

--- a/packages/web/app/privacy/page.tsx
+++ b/packages/web/app/privacy/page.tsx
@@ -54,7 +54,7 @@ const notStored = [
 
 export default function PrivacyPage() {
   return (
-    <main className="min-h-screen bg-white py-12 px-4">
+    <main className="mx-auto min-h-screen max-w-3xl px-5 pb-24 pt-10">
       <div className="max-w-3xl mx-auto space-y-10">
         <div className="space-y-2">
           <Link href="/" className="text-sm text-blue-600 hover:underline">

--- a/packages/web/app/robots.ts
+++ b/packages/web/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/account", "/api/", "/onboard/verify"],
+      },
+    ],
+    sitemap: "https://ato-mcp.com.au/sitemap.xml",
+  };
+}

--- a/packages/web/app/sitemap.ts
+++ b/packages/web/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+const SITE = "https://ato-mcp.com.au";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  return [
+    { url: `${SITE}/`, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${SITE}/docs`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${SITE}/onboard`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${SITE}/privacy`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
+    { url: `${SITE}/terms`, lastModified: now, changeFrequency: "monthly", priority: 0.4 },
+  ];
+}

--- a/packages/web/app/terms/page.tsx
+++ b/packages/web/app/terms/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function TermsPage() {
   return (
-    <main className="min-h-screen bg-white py-12 px-4">
+    <main className="mx-auto min-h-screen max-w-3xl px-5 pb-24 pt-10">
       <div className="max-w-3xl mx-auto space-y-10">
         <div className="space-y-2">
           <Link href="/" className="text-sm text-blue-600 hover:underline">

--- a/packages/web/components/site/Footer.tsx
+++ b/packages/web/components/site/Footer.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+
+export function Footer() {
+  return (
+    <footer className="relative overflow-hidden rounded-t-[1.6rem] bg-night px-6 pb-8 pt-16 text-white/70 sm:px-10">
+      <div className="mx-auto max-w-6xl">
+        <div className="grid gap-10 md:grid-cols-4">
+          <div className="md:col-span-2">
+            <p className="text-sm font-semibold text-white">ato-mcp</p>
+            <p className="mt-2 max-w-sm text-sm leading-relaxed">
+              The Australian tax knowledge base for AI agents — cited retrieval,
+              personal context, and tax workflow tools over the Model Context
+              Protocol. Open source, local or hosted.
+            </p>
+            <p className="mt-4 text-xs text-white/40">
+              Information infrastructure, not tax advice. Verify material
+              decisions with a registered tax agent.
+            </p>
+          </div>
+          <nav aria-label="Product" className="text-sm">
+            <p className="eyebrow mb-3 text-white/40">Product</p>
+            <ul className="space-y-2">
+              <li><Link className="transition-colors hover:text-white" href="/docs">Documentation</Link></li>
+              <li><Link className="transition-colors hover:text-white" href="/onboard">Get started</Link></li>
+              <li><Link className="transition-colors hover:text-white" href="/account">Account</Link></li>
+              <li>
+                <a className="transition-colors hover:text-white" href="https://github.com/william-laverty/ato-mcp" target="_blank" rel="noopener noreferrer">
+                  GitHub ↗
+                </a>
+              </li>
+              <li>
+                <a className="transition-colors hover:text-white" href="https://www.npmjs.com/package/@ato-mcp/mcp" target="_blank" rel="noopener noreferrer">
+                  npm ↗
+                </a>
+              </li>
+            </ul>
+          </nav>
+          <nav aria-label="Legal" className="text-sm">
+            <p className="eyebrow mb-3 text-white/40">Trust</p>
+            <ul className="space-y-2">
+              <li><Link className="transition-colors hover:text-white" href="/privacy">Privacy</Link></li>
+              <li><Link className="transition-colors hover:text-white" href="/terms">Terms</Link></li>
+              <li>
+                <a className="transition-colors hover:text-white" href="https://github.com/william-laverty/ato-mcp/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">
+                  Security ↗
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+
+        <div className="mt-12 flex flex-col gap-2 border-t border-white/10 pt-6 text-xs text-white/40 sm:flex-row sm:items-center sm:justify-between">
+          <p>© {new Date().getFullYear()} William Laverty · MIT licensed</p>
+          <p>ATO content remains subject to ATO publication terms.</p>
+        </div>
+
+        <p aria-hidden="true" className="wordmark mt-10 text-center text-[clamp(4.5rem,18vw,15rem)]">
+          ato-mcp
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/packages/web/components/site/Nav.tsx
+++ b/packages/web/components/site/Nav.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+const LINKS = [
+  { href: "/docs", label: "Docs" },
+  { href: "/#tools", label: "Tools" },
+  { href: "/#modes", label: "Local & hosted" },
+  { href: "/privacy", label: "Privacy" },
+];
+
+/**
+ * Fixed pill navigation. Transparent and wide at the top of the page;
+ * compresses into a frosted-glass pill once the user scrolls.
+ */
+export function Nav() {
+  const [scrolled, setScrolled] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 24);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <header className="fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-4">
+      <nav
+        aria-label="Main"
+        className={[
+          "flex w-full items-center justify-between rounded-full border px-5 transition-all duration-500",
+          scrolled
+            ? "max-w-4xl border-black/10 bg-white/80 py-2.5 shadow-[0_8px_32px_rgba(0,0,0,0.1)] backdrop-blur-xl"
+            : "max-w-6xl border-transparent bg-transparent py-3.5",
+        ].join(" ")}
+      >
+        <Link
+          href="/"
+          className="flex items-center gap-2 font-semibold tracking-snugger text-ink"
+          aria-label="ato-mcp home"
+        >
+          <svg width="22" height="22" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+            <rect x="2" y="2" width="28" height="28" rx="9" fill="#5039bd" />
+            <circle cx="12" cy="16" r="3.2" fill="#f4f2f7" />
+            <circle cx="21.5" cy="10.5" r="2.3" fill="#c794ff" />
+            <circle cx="21.5" cy="21.5" r="2.3" fill="#ff9a3c" />
+            <path d="M14.8 14.6l4.4-3M14.8 17.4l4.4 3" stroke="#f4f2f7" strokeWidth="1.6" />
+          </svg>
+          ato-mcp
+        </Link>
+
+        <div className="hidden items-center gap-6 md:flex">
+          {LINKS.map((l) => (
+            <Link
+              key={l.href}
+              href={l.href}
+              className="text-[0.8rem] font-medium text-ink/70 transition-colors hover:text-ink"
+            >
+              {l.label}
+            </Link>
+          ))}
+          <a
+            href="https://github.com/william-laverty/ato-mcp"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[0.8rem] font-medium text-ink/70 transition-colors hover:text-ink"
+          >
+            GitHub
+          </a>
+          <Link href="/onboard" className="btn btn-solid px-4 py-2 text-[0.8rem]">
+            Get started
+          </Link>
+        </div>
+
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-label="Toggle menu"
+          onClick={() => setOpen(!open)}
+          className="flex h-9 w-9 items-center justify-center rounded-full border border-black/10 bg-white/70 md:hidden"
+        >
+          <svg width="15" height="15" viewBox="0 0 14 14" aria-hidden="true">
+            {open ? (
+              <path d="M2 2l10 10M12 2L2 12" stroke="#0b0b14" strokeWidth="1.6" strokeLinecap="round" />
+            ) : (
+              <g fill="#0b0b14">
+                <circle cx="3" cy="3" r="1.4" /><circle cx="11" cy="3" r="1.4" />
+                <circle cx="3" cy="11" r="1.4" /><circle cx="11" cy="11" r="1.4" />
+              </g>
+            )}
+          </svg>
+        </button>
+      </nav>
+
+      {open && (
+        <div className="absolute inset-x-4 top-[4.4rem] rounded-2xl border border-black/10 bg-white/95 p-4 shadow-xl backdrop-blur-xl md:hidden">
+          <div className="flex flex-col gap-1">
+            {LINKS.map((l) => (
+              <Link
+                key={l.href}
+                href={l.href}
+                onClick={() => setOpen(false)}
+                className="rounded-lg px-3 py-2.5 text-sm font-medium text-ink/80 hover:bg-black/5"
+              >
+                {l.label}
+              </Link>
+            ))}
+            <a
+              href="https://github.com/william-laverty/ato-mcp"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg px-3 py-2.5 text-sm font-medium text-ink/80 hover:bg-black/5"
+            >
+              GitHub
+            </a>
+            <Link
+              href="/onboard"
+              onClick={() => setOpen(false)}
+              className="btn btn-solid mt-2 px-4 py-2.5 text-sm"
+            >
+              Get started
+            </Link>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/packages/web/lib/tools-meta.ts
+++ b/packages/web/lib/tools-meta.ts
@@ -1,0 +1,89 @@
+/** Website-facing tool summaries. Full reference: docs/tools.md in the repo. */
+
+export interface ToolMeta {
+  name: string;
+  group: "Retrieval" | "Personal context" | "Workflows";
+  summary: string;
+  example: string;
+}
+
+export const TOOLS_META: ToolMeta[] = [
+  {
+    name: "search",
+    group: "Retrieval",
+    summary: "Hybrid BM25 + vector search over the whole corpus, rank-fused, point-in-time aware.",
+    example: `search({ query: "instant asset write-off eligibility", k: 5 })`,
+  },
+  {
+    name: "get_chunks",
+    group: "Retrieval",
+    summary: "Resolve chunk_ids to full passages with optional neighbouring context.",
+    example: `get_chunks({ chunk_ids: ["legis:…/8-1#0"], neighbours: 1 })`,
+  },
+  {
+    name: "get_doc",
+    group: "Retrieval",
+    summary: "Fetch a whole document — metadata plus its anchor list.",
+    example: `get_doc({ doc_id: "legis:c2004a05138/8-1" })`,
+  },
+  {
+    name: "get_doc_anchors",
+    group: "Retrieval",
+    summary: "The citation graph around a document: anchors, inbound and outbound references.",
+    example: `get_doc_anchors({ doc_id: "legis:c2004a05138/8-1" })`,
+  },
+  {
+    name: "get_definition",
+    group: "Retrieval",
+    summary: "Statutory definitions (ITAA 1997 Dictionary and friends), point-in-time selectable.",
+    example: `get_definition({ term: "depreciating asset" })`,
+  },
+  {
+    name: "get_threshold",
+    group: "Retrieval",
+    summary: "Time-keyed scalar facts — IAWO limit, GST registration threshold, CGT discount, super caps.",
+    example: `get_threshold({ name: "instant_asset_write_off" })`,
+  },
+  {
+    name: "fetch",
+    group: "Retrieval",
+    summary: "Live-fetch a page by URI scheme (ato:, ato-law:, legis:) when freshness matters.",
+    example: `fetch({ uri: "ato:tax-rates-and-codes/…" })`,
+  },
+  {
+    name: "stats",
+    group: "Retrieval",
+    summary: "Corpus snapshot: counts, schema version, staleness.",
+    example: `stats({})`,
+  },
+  {
+    name: "get_user_facts",
+    group: "Personal context",
+    summary: "Your onboarded profile — 25 facts the agent reads once per session instead of re-asking.",
+    example: `get_user_facts({})`,
+  },
+  {
+    name: "deduction_discovery",
+    group: "Workflows",
+    summary: "Every plausibly-applicable deduction category for your taxpayer shape, cited and confidence-rated.",
+    example: `deduction_discovery({ activity: "bought a laptop" })`,
+  },
+  {
+    name: "depreciation_helper",
+    group: "Workflows",
+    summary: "Prime-cost / diminishing-value / IAWO / pool / Div 43 schedules, computed deterministically.",
+    example: `depreciation_helper({ asset_cost: 4800, acquisition_date: "2025-09-01", effective_life_years: 3 })`,
+  },
+  {
+    name: "bas_prep_checklist",
+    group: "Workflows",
+    summary: "A tiered, cited BAS checklist for your reporting period — labels, evidence, gotchas.",
+    example: `bas_prep_checklist({ period_type: "quarterly", quarter: 2 })`,
+  },
+  {
+    name: "audit_risk_check",
+    group: "Workflows",
+    summary: "Heuristic ATO red-flags over a draft return, risk-banded with the guidance behind each.",
+    example: `audit_risk_check({ income: 90000, deductions: [...] })`,
+  },
+];

--- a/packages/web/public/llms.txt
+++ b/packages/web/public/llms.txt
@@ -1,0 +1,26 @@
+# ato-mcp
+
+> The Australian tax knowledge base for AI agents: an open-source MCP (Model Context
+> Protocol) server giving cited retrieval over 29,000+ ATO documents, the Income Tax
+> Assessment Act 1997 and 2,127 public rulings, plus a personal-facts layer and four
+> tax workflow tools (deduction_discovery, depreciation_helper, bas_prep_checklist,
+> audit_risk_check). Runs fully local (SQLite + ONNX, offline) or hosted
+> (api.ato-mcp.com.au). MIT licensed. Not tax advice: every tool returns structured
+> data plus resolvable ATO citations for an agent to reason over.
+
+## Docs
+
+- [Documentation](https://ato-mcp.com.au/docs): install (hosted or local), connect to Claude Code / any MCP host, all 13 tools
+- [Full tool reference](https://github.com/william-laverty/ato-mcp/blob/main/docs/tools.md): input/output schemas, examples, errors
+- [README](https://github.com/william-laverty/ato-mcp/blob/main/README.md): corpus contents, architecture, privacy model
+- [Self-hosting](https://github.com/william-laverty/ato-mcp/blob/main/docs/self-hosting.md): run your own Supabase + Vercel stack
+
+## Install
+
+- npm package: @ato-mcp/mcp (Node 22+). Hosted: `ato-mcp onboard`. Local: `ato-mcp update` (sha256-verified ~1 GB corpus).
+- Claude Code: `claude mcp add ato-mcp -- ato-mcp mcp`
+
+## Policies
+
+- [Privacy](https://ato-mcp.com.au/privacy): generated from the database schema; hosted mode never stores queries, tool names or results
+- [Terms](https://ato-mcp.com.au/terms)

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -7,7 +7,47 @@ const config: Config = {
     "./lib/**/*.{ts,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ["var(--font-sans)", "Arial", "sans-serif"],
+        serif: ["var(--font-serif)", "Georgia", "serif"],
+        mono: ["var(--font-mono)", "ui-monospace", "monospace"],
+      },
+      colors: {
+        ink: "#0b0b14",
+        paper: "#f5f5f7",
+        night: "#05030f",
+        brand: {
+          DEFAULT: "#5039bd",
+          bright: "#7a5cff",
+          soft: "#c794ff",
+        },
+        ember: "#ff9a3c",
+      },
+      letterSpacing: {
+        snugger: "-0.02em",
+        caps: "0.14em",
+      },
+      animation: {
+        chipMarquee: "chipMarquee 32s linear infinite",
+        shimmer: "shimmer 2.6s ease-in-out infinite",
+        floatSlow: "floatSlow 7s ease-in-out infinite",
+      },
+      keyframes: {
+        chipMarquee: {
+          from: { transform: "translateX(0)" },
+          to: { transform: "translateX(-50%)" },
+        },
+        shimmer: {
+          "0%, 100%": { backgroundPosition: "120% 0" },
+          "50%": { backgroundPosition: "-20% 0" },
+        },
+        floatSlow: {
+          "0%, 100%": { transform: "translateY(0)" },
+          "50%": { transform: "translateY(-6px)" },
+        },
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- Complete marketing rebuild in the heynox aesthetic (dark mesh hero card + cited-answer terminal, glass pill nav, bento stats, workflows showcase, modes, FAQ, giant footer wordmark) — CSS-only motion, reduced-motion safe
- New `/docs`, 404, dynamic OG image, icon, robots, sitemap, llms.txt
- SEO: metadata + canonicals + OG/Twitter + JSON-LD (Org/WebSite/SoftwareApplication/FAQPage/TechArticle)
- App machinery untouched; privacy/terms re-shelled only
- Adds the Supabase→SQLite corpus export script (release tooling)

## Test Plan
- [x] `pnpm --filter @ato-mcp/web typecheck/build/test` green (privacy contract test passes)
- [x] Playwright: desktop + mobile + docs + onboard + 404 — zero console errors; scroll reveals verified
- [x] curl: title/canonical/OG-image/sitemap/robots/llms.txt/icon all 200
- [ ] Vercel preview deploy green → merge → verify live

🤖 Generated with [Claude Code](https://claude.com/claude-code)