### PR TITLE
ci: bump actions to Node-24 majors + tokenless npm publish (OIDC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
   node:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,19 +6,20 @@ on:
 
 jobs:
   publish:
-    # Only software releases (v*). No-ops gracefully until NPM_PUBLISH_ENABLED is
-    # set and the NPM_TOKEN secret is configured. Publishes the unscoped `ato-mcp`
-    # client only — it has no runtime dependency on @ato-mcp/shared (shared is a
-    # dev-only dependency used by tests), so shared is not published.
+    # Only software releases (v*). Publishes the unscoped `ato-mcp` client via npm
+    # Trusted Publishing (OIDC) — no NPM_TOKEN needed. Requires the package's
+    # Trusted Publisher to be configured on npmjs.com (GitHub Actions →
+    # william-laverty/ato-mcp → npm-publish.yml). pnpm performs the OIDC exchange.
+    # The NPM_PUBLISH_ENABLED gate stays as an explicit publish safety switch.
     if: startsWith(github.event.release.tag_name, 'v') && vars.NPM_PUBLISH_ENABLED == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write   # npm provenance
+      id-token: write   # OIDC for Trusted Publishing + provenance
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -26,7 +27,5 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r build
       - run: pnpm --filter ato-mcp test
-      - name: Publish ato-mcp
+      - name: Publish ato-mcp (OIDC trusted publishing)
         run: pnpm --filter ato-mcp publish --access public --no-git-checks --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What
- Bump GitHub Actions to their Node-24 majors — `actions/checkout@v6`, `actions/setup-node@v6`, `pnpm/action-setup@v6` — clearing the *Node 20 deprecation* notice (GitHub forces Node 24 from Sept 2026).
- Switch `npm-publish.yml` to **npm Trusted Publishing (OIDC)**: drop `NODE_AUTH_TOKEN`, keep `id-token: write` + `registry-url` + `--provenance`. pnpm 10.28.2 performs the OIDC exchange. The `ato-mcp` package's Trusted Publisher is configured on npmjs.com (GitHub Actions → william-laverty/ato-mcp → npm-publish.yml).

## Why
No long-lived npm token to store/rotate; the bootstrap `NPM_TOKEN` secret can be deleted after this merges. The `NPM_PUBLISH_ENABLED` gate stays as a publish safety switch.

## Validation
This PR's CI exercises the bumped `ci.yml`. The tokenless publish path runs on the next `v*` release (it can't be exercised by a PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)