### PR TITLE
Redesign landing page: framed hero card, re-slotted navbar, rounded footer

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -56,6 +56,25 @@ body {
     @apply relative overflow-hidden rounded-[15px] border border-black/[0.04] bg-zinc-50;
   }
 
+  /* --- Hero card: large rounded framing on warm paper ------------------- */
+  .hero-card {
+    @apply relative overflow-hidden rounded-[24px] border border-black/5 bg-[#fcfbf9] shadow-[0_1px_2px_rgba(0,0,0,0.04),0_24px_60px_-28px_rgba(0,0,0,0.12)];
+  }
+  /* Subtle warm vermillion glow bleeding from the upper-left (decorative). */
+  .hero-glow {
+    @apply pointer-events-none absolute inset-0;
+    background: radial-gradient(
+      60% 55% at 12% 22%,
+      rgba(250, 82, 15, 0.07) 0%,
+      transparent 60%
+    );
+  }
+
+  /* --- Footer card: rounded inset block (superpower section_footer3) ---- */
+  .footer-card {
+    @apply rounded-[24px] border border-black/5 bg-zinc-50 shadow-[0_1px_2px_rgba(0,0,0,0.04),0_20px_50px_-28px_rgba(0,0,0,0.1)];
+  }
+
   /* --- Citation chip: the one place the accent lives ------------------- */
   .chip {
     @apply inline-flex items-center gap-1.5 whitespace-nowrap rounded-[5px] bg-brand-50 px-2 py-0.5 font-mono text-[0.6875rem] text-brand-text;

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Fragment } from "react";
 import Link from "next/link";
 
 export const metadata: Metadata = {
@@ -11,10 +12,10 @@ export const metadata: Metadata = {
    citation chips and small markers. The product demo card is the hero image.
 --------------------------------------------------------------------------- */
 
-const HERO_STATS = [
-  { n: "29,181", label: "ATO documents" },
-  { n: "2,127", label: "public rulings" },
-  { n: "13", label: "MCP tools" },
+const HERO_TRUST = [
+  { title: "Cited retrieval", sub: "every answer sourced" },
+  { title: "29,000+ documents", sub: "refreshed monthly" },
+  { title: "Any MCP host", sub: "Claude Code & Desktop" },
 ];
 
 const CORPUS_STATS = [
@@ -205,6 +206,28 @@ function HeroDemo() {
   );
 }
 
+/** heynox-style trust strip, light: title/subtitle pairs split by hairlines. */
+function HeroTrust({ className = "" }: { className?: string }) {
+  return (
+    <dl className={`flex w-fit flex-wrap items-center gap-x-6 gap-y-4 ${className}`}>
+      {HERO_TRUST.map((t, i) => (
+        <Fragment key={t.title}>
+          {i > 0 && (
+            <span
+              className="hidden h-9 w-px shrink-0 bg-zinc-200 sm:block"
+              aria-hidden="true"
+            />
+          )}
+          <div>
+            <dt className="text-sm text-zinc-900">{t.title}</dt>
+            <dd className="text-sm text-zinc-400">{t.sub}</dd>
+          </div>
+        </Fragment>
+      ))}
+    </dl>
+  );
+}
+
 export default function HomePage() {
   return (
     <main>
@@ -214,66 +237,64 @@ export default function HomePage() {
       />
 
       {/* ------------------------------------------------ hero */}
-      <section className="relative overflow-hidden">
-        <div className="mx-auto max-w-6xl px-5 pb-14 pt-16 sm:pt-24">
-          <div className="relative grid items-center gap-12 lg:grid-cols-[1.05fr_0.95fr]">
-            <div>
-              <p
-                className="reveal inline-flex items-center gap-2 font-mono text-[0.6875rem] uppercase tracking-[0.08em] text-zinc-500"
-                style={{ "--reveal-delay": "0s" } as React.CSSProperties}
-              >
-                <span className="inline-block h-1.5 w-1.5 rounded-full bg-brand" />
-                v1.1 · open source · MIT
-              </p>
-              <h1
-                className="reveal mt-5 text-[clamp(2.5rem,5vw,3.5rem)] font-normal leading-[1.04] tracking-tight2 text-zinc-900"
-                style={{ "--reveal-delay": "0.08s" } as React.CSSProperties}
-              >
-                Your AI agent, fluent in Australian tax
-              </h1>
-              <p
-                className="reveal mt-5 max-w-xl text-[15px] leading-relaxed text-zinc-500"
-                style={{ "--reveal-delay": "0.16s" } as React.CSSProperties}
-              >
-                Connect Claude — or any MCP agent — to 29,000+ ATO documents,
-                the ITAA 1997 and 2,127 public rulings. Every answer comes with
-                the section, the ruling and the page.
-              </p>
-              <div
-                className="reveal mt-8 flex flex-wrap items-center gap-3"
-                style={{ "--reveal-delay": "0.24s" } as React.CSSProperties}
-              >
-                <Link href="/onboard" className="btn btn-primary px-6 py-3 text-sm">
-                  Get started free
-                </Link>
-                <Link href="/docs" className="btn btn-outline px-6 py-3 text-sm">
-                  Read the docs
-                </Link>
-              </div>
-              <p
-                className="reveal mt-5 font-mono text-xs text-zinc-400"
-                style={{ "--reveal-delay": "0.3s" } as React.CSSProperties}
-              >
-                npx -y ato-mcp · works with Claude Code, Claude Desktop
-                &amp; any MCP host
-              </p>
-            </div>
-            <div className="relative">
-              <CitationGraphMotif />
-              <HeroDemo />
-            </div>
-          </div>
-
-          {/* stat strip */}
-          <div className="mt-16 flex flex-wrap gap-x-12 gap-y-6 border-t border-zinc-100 pt-7">
-            {HERO_STATS.map((s) => (
-              <div key={s.label}>
-                <p className="text-xl tracking-tight1 text-zinc-900">{s.n}</p>
-                <p className="mt-0.5 font-mono text-[0.6875rem] text-zinc-400">
-                  {s.label}
+      <section className="relative">
+        <div className="px-3 pb-3 pt-3">
+          <div className="hero-card flex min-h-[600px] items-center lg:min-h-[calc(100svh-24px)]">
+            <span className="hero-glow" aria-hidden="true" />
+            <div className="relative grid w-full items-center gap-12 px-[clamp(28px,6vw,88px)] py-28 lg:grid-cols-[1.05fr_0.95fr] lg:py-24">
+              <div>
+                <span
+                  className="reveal inline-flex items-center gap-2 rounded-full border border-black/5 bg-white px-3 py-1 font-mono text-[0.6875rem] uppercase tracking-[0.08em] text-zinc-500 shadow-[0_1px_2px_rgba(0,0,0,0.04)]"
+                  style={{ "--reveal-delay": "0s" } as React.CSSProperties}
+                >
+                  <span className="inline-block h-1.5 w-1.5 rounded-full bg-brand" />
+                  v1.1 · open source · MIT
+                </span>
+                <h1
+                  className="reveal mt-5 text-[clamp(2.5rem,5vw,3.5rem)] font-normal leading-[1.04] tracking-tight2 text-zinc-900"
+                  style={{ "--reveal-delay": "0.08s" } as React.CSSProperties}
+                >
+                  Your AI agent, fluent in Australian tax
+                </h1>
+                <p
+                  className="reveal mt-5 max-w-xl text-[15px] leading-relaxed text-zinc-500"
+                  style={{ "--reveal-delay": "0.16s" } as React.CSSProperties}
+                >
+                  Connect Claude — or any MCP agent — to 29,000+ ATO documents,
+                  the ITAA 1997 and 2,127 public rulings. Every answer comes with
+                  the section, the ruling and the page.
                 </p>
+                <div
+                  className="reveal mt-8 flex flex-wrap items-center gap-3"
+                  style={{ "--reveal-delay": "0.24s" } as React.CSSProperties}
+                >
+                  <Link href="/onboard" className="btn btn-primary px-6 py-3 text-sm">
+                    Get started free
+                  </Link>
+                  <Link href="/docs" className="btn btn-outline px-6 py-3 text-sm">
+                    Read the docs
+                  </Link>
+                </div>
+                <p
+                  className="reveal mt-5 font-mono text-xs text-zinc-400"
+                  style={{ "--reveal-delay": "0.3s" } as React.CSSProperties}
+                >
+                  npx -y ato-mcp · works with Claude Code, Claude Desktop
+                  &amp; any MCP host
+                </p>
+
+                {/* Mobile trust strip — in-flow (the desktop one is pinned below) */}
+                <HeroTrust className="reveal mt-10 lg:hidden" />
               </div>
-            ))}
+
+              <div className="relative">
+                <CitationGraphMotif />
+                <HeroDemo />
+              </div>
+            </div>
+
+            {/* Desktop trust strip — pinned to the card's bottom-left */}
+            <HeroTrust className="absolute bottom-[clamp(28px,5vh,56px)] left-[clamp(28px,6vw,88px)] hidden lg:flex" />
           </div>
         </div>
       </section>

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -209,7 +209,7 @@ function HeroDemo() {
 /** heynox-style trust strip, light: title/subtitle pairs split by hairlines. */
 function HeroTrust({ className = "" }: { className?: string }) {
   return (
-    <dl className={`flex w-fit flex-wrap items-center gap-x-6 gap-y-4 ${className}`}>
+    <dl className={`flex flex-wrap items-center gap-x-6 gap-y-4 ${className}`}>
       {HERO_TRUST.map((t, i) => (
         <Fragment key={t.title}>
           {i > 0 && (
@@ -243,13 +243,13 @@ export default function HomePage() {
             <span className="hero-glow" aria-hidden="true" />
             <div className="relative grid w-full items-center gap-12 px-[clamp(28px,6vw,88px)] py-28 lg:grid-cols-[1.05fr_0.95fr] lg:py-24">
               <div>
-                <span
+                <p
                   className="reveal inline-flex items-center gap-2 rounded-full border border-black/5 bg-white px-3 py-1 font-mono text-[0.6875rem] uppercase tracking-[0.08em] text-zinc-500 shadow-[0_1px_2px_rgba(0,0,0,0.04)]"
                   style={{ "--reveal-delay": "0s" } as React.CSSProperties}
                 >
                   <span className="inline-block h-1.5 w-1.5 rounded-full bg-brand" />
                   v1.1 · open source · MIT
-                </span>
+                </p>
                 <h1
                   className="reveal mt-5 text-[clamp(2.5rem,5vw,3.5rem)] font-normal leading-[1.04] tracking-tight2 text-zinc-900"
                   style={{ "--reveal-delay": "0.08s" } as React.CSSProperties}
@@ -284,7 +284,7 @@ export default function HomePage() {
                 </p>
 
                 {/* Mobile trust strip — in-flow (the desktop one is pinned below) */}
-                <HeroTrust className="reveal mt-10 lg:hidden" />
+                <HeroTrust className="reveal mt-10 w-full border-t border-zinc-100 pt-6 lg:hidden" />
               </div>
 
               <div className="relative">

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -237,7 +237,10 @@ export default function HomePage() {
       />
 
       {/* ------------------------------------------------ hero */}
-      <section className="relative">
+      {/* -mt-16 cancels the layout's global `pt-16` (which clears the fixed nav
+          for every other page) so the hero card goes full-bleed to the top and
+          the nav floats *over* the card — content is centred well clear of it. */}
+      <section className="relative -mt-16">
         <div className="px-3 pb-3 pt-3">
           <div className="hero-card flex min-h-[600px] items-center lg:min-h-[calc(100svh-24px)]">
             <span className="hero-glow" aria-hidden="true" />

--- a/packages/web/components/site/Footer.tsx
+++ b/packages/web/components/site/Footer.tsx
@@ -1,57 +1,89 @@
 import Link from "next/link";
 
+function Mark({ size = 22 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="none"
+      aria-hidden="true"
+    >
+      <rect x="1" y="1" width="30" height="30" rx="8.5" fill="#fa520f" />
+      <circle cx="10.5" cy="16" r="2.6" fill="#ffffff" />
+      <rect x="15" y="13.9" width="7.5" height="4.2" rx="2.1" fill="#ffffff" />
+    </svg>
+  );
+}
+
 export function Footer() {
   return (
-    <footer className="border-t border-zinc-200 bg-white px-5 pb-10 pt-14 text-zinc-500">
-      <div className="mx-auto max-w-6xl">
-        <div className="grid gap-10 md:grid-cols-4">
-          <div className="md:col-span-2">
-            <p className="text-sm font-medium text-zinc-900">ato-mcp</p>
-            <p className="mt-2 max-w-sm text-sm leading-relaxed">
-              The Australian tax knowledge base for AI agents — cited retrieval,
-              personal context, and tax workflow tools over the Model Context
-              Protocol. Open source.
-            </p>
-            <p className="mt-4 text-xs text-zinc-400">
-              Information infrastructure, not tax advice. Verify material
-              decisions with a registered tax agent.
-            </p>
+    <footer className="px-3 pb-3">
+      <div className="footer-card px-6 pb-8 pt-14 text-zinc-500 sm:px-10">
+        <div className="mx-auto max-w-6xl">
+          <div className="grid gap-10 md:grid-cols-4">
+            <div className="md:col-span-2">
+              <div className="flex items-center gap-2">
+                <Mark />
+                <span className="text-[15px] font-medium tracking-tight1 text-zinc-900">
+                  ato-mcp
+                </span>
+              </div>
+              <p className="mt-3 max-w-sm text-sm leading-relaxed">
+                The Australian tax knowledge base for AI agents — cited retrieval,
+                personal context, and tax workflow tools over the Model Context
+                Protocol. Open source.
+              </p>
+              <p className="mt-4 text-xs text-zinc-400">
+                Information infrastructure, not tax advice. Verify material
+                decisions with a registered tax agent.
+              </p>
+            </div>
+            <nav aria-label="Product" className="text-sm">
+              <p className="eyebrow mb-3">Product</p>
+              <ul className="space-y-2">
+                <li><Link className="transition-colors hover:text-zinc-900" href="/docs">Documentation</Link></li>
+                <li><Link className="transition-colors hover:text-zinc-900" href="/onboard">Get started</Link></li>
+                <li><Link className="transition-colors hover:text-zinc-900" href="/account">Account</Link></li>
+                <li>
+                  <a className="transition-colors hover:text-zinc-900" href="https://github.com/william-laverty/ato-mcp" target="_blank" rel="noopener noreferrer">
+                    GitHub ↗
+                  </a>
+                </li>
+                <li>
+                  <a className="transition-colors hover:text-zinc-900" href="https://www.npmjs.com/package/ato-mcp" target="_blank" rel="noopener noreferrer">
+                    npm ↗
+                  </a>
+                </li>
+              </ul>
+            </nav>
+            <nav aria-label="Trust" className="text-sm">
+              <p className="eyebrow mb-3">Trust</p>
+              <ul className="space-y-2">
+                <li><Link className="transition-colors hover:text-zinc-900" href="/privacy">Privacy</Link></li>
+                <li><Link className="transition-colors hover:text-zinc-900" href="/terms">Terms</Link></li>
+                <li>
+                  <a className="transition-colors hover:text-zinc-900" href="https://github.com/william-laverty/ato-mcp/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">
+                    Security ↗
+                  </a>
+                </li>
+              </ul>
+            </nav>
           </div>
-          <nav aria-label="Product" className="text-sm">
-            <p className="eyebrow mb-3">Product</p>
-            <ul className="space-y-2">
-              <li><Link className="transition-colors hover:text-zinc-900" href="/docs">Documentation</Link></li>
-              <li><Link className="transition-colors hover:text-zinc-900" href="/onboard">Get started</Link></li>
-              <li><Link className="transition-colors hover:text-zinc-900" href="/account">Account</Link></li>
-              <li>
-                <a className="transition-colors hover:text-zinc-900" href="https://github.com/william-laverty/ato-mcp" target="_blank" rel="noopener noreferrer">
-                  GitHub ↗
-                </a>
-              </li>
-              <li>
-                <a className="transition-colors hover:text-zinc-900" href="https://www.npmjs.com/package/ato-mcp" target="_blank" rel="noopener noreferrer">
-                  npm ↗
-                </a>
-              </li>
-            </ul>
-          </nav>
-          <nav aria-label="Legal" className="text-sm">
-            <p className="eyebrow mb-3">Trust</p>
-            <ul className="space-y-2">
-              <li><Link className="transition-colors hover:text-zinc-900" href="/privacy">Privacy</Link></li>
-              <li><Link className="transition-colors hover:text-zinc-900" href="/terms">Terms</Link></li>
-              <li>
-                <a className="transition-colors hover:text-zinc-900" href="https://github.com/william-laverty/ato-mcp/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">
-                  Security ↗
-                </a>
-              </li>
-            </ul>
-          </nav>
-        </div>
 
-        <div className="mt-12 flex flex-col gap-2 border-t border-zinc-100 pt-6 text-xs text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
-          <p>© {new Date().getFullYear()} William Laverty · MIT licensed</p>
-          <p>ATO content remains subject to ATO publication terms.</p>
+          {/* Oversized wordmark — the one superpower-style flourish (decorative). */}
+          <p
+            className="mt-14 select-none text-[clamp(3.5rem,14vw,9rem)] font-medium leading-none tracking-tight2 text-zinc-200"
+            aria-hidden="true"
+          >
+            ato-mcp
+          </p>
+
+          {/* Legal bar */}
+          <div className="mt-10 flex flex-col gap-2 border-t border-zinc-200 pt-6 text-xs text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
+            <p>© {new Date().getFullYear()} William Laverty · MIT licensed</p>
+            <p>ATO content remains subject to ATO publication terms.</p>
+          </div>
         </div>
       </div>
     </footer>

--- a/packages/web/components/site/Nav.tsx
+++ b/packages/web/components/site/Nav.tsx
@@ -29,7 +29,7 @@ function Mark({ size = 20 }: { size?: number }) {
 
 /**
  * Scroll-aware nav: at the top of the page it reads as a full-width
- * transparent bar — links left, logo centre, CTA right. Scrolling collapses
+ * transparent bar — logo left, links centre, CTA right. Scrolling collapses
  * it into a centred floating glass pill (white/80 + blur + hairline + soft
  * shadow). On mobile the pill is always painted and expands downward to
  * reveal the menu.
@@ -84,7 +84,7 @@ export function Nav() {
           scrolled ? "max-w-3xl" : "max-w-6xl",
         ].join(" ")}
       >
-        {/* Nav pill — links | logo | CTA. Transparent at top, glass on scroll. */}
+        {/* Nav pill — logo | links | CTA. Transparent at top, glass on scroll. */}
         <nav
           aria-label="Main"
           className={[
@@ -97,8 +97,18 @@ export function Nav() {
         >
           {/* Top row: contents on desktop so the grid owns layout; flex row on mobile. */}
           <div className="[display:contents] max-md:flex max-md:w-full max-md:items-center max-md:justify-between">
-            {/* Left — links */}
-            <div className="group flex items-center gap-1 justify-self-start max-md:hidden">
+            {/* Left — logo */}
+            <Link
+              href="/"
+              className="flex items-center gap-2 justify-self-start px-2 py-1 text-[15px] font-medium tracking-tight1 text-zinc-900 max-md:px-0"
+              aria-label="ato-mcp home"
+            >
+              <Mark />
+              ato-mcp
+            </Link>
+
+            {/* Centre — links */}
+            <div className="group flex items-center gap-1 justify-self-center max-md:hidden">
               {LINKS.map((l) => (
                 <Link
                   key={l.href}
@@ -110,26 +120,8 @@ export function Nav() {
               ))}
             </div>
 
-            {/* Centre — logo */}
-            <Link
-              href="/"
-              className="flex items-center gap-2 justify-self-center px-2 py-1 text-[15px] font-medium tracking-tight1 text-zinc-900 max-md:px-0"
-              aria-label="ato-mcp home"
-            >
-              <Mark />
-              ato-mcp
-            </Link>
-
-            {/* Right — GitHub + CTA */}
+            {/* Right — CTA */}
             <div className="flex items-center gap-1 justify-self-end">
-              <a
-                href="https://github.com/william-laverty/ato-mcp"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="rounded-full px-3 py-1.5 text-[13px] text-zinc-700 transition-colors hover:text-zinc-900 max-md:hidden"
-              >
-                GitHub
-              </a>
               <Link
                 href="/onboard"
                 className="btn btn-primary px-4 py-2 text-[13px] max-md:hidden"
@@ -182,15 +174,6 @@ export function Nav() {
                     {l.label}
                   </Link>
                 ))}
-                <a
-                  href="https://github.com/william-laverty/ato-mcp"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  tabIndex={open ? 0 : -1}
-                  className="rounded-lg px-3 py-2.5 text-sm text-zinc-700 hover:bg-zinc-50"
-                >
-                  GitHub
-                </a>
                 <Link
                   href="/onboard"
                   onClick={() => setOpen(false)}


### PR DESCRIPTION
## Summary

A presentational redesign of the `ato-mcp.com.au` landing page, adapting layout patterns from two reference sites while staying entirely within the existing light **Clinical** palette (paper-white + a single vermillion accent).

- **Navbar** — re-slotted to **logo (left) · links Docs/Tools/Privacy (centre) · `Get started` (right)**; the GitHub nav item is removed (it intentionally stays in the footer + final-CTA). Scroll/glass-pill + mobile-menu mechanics unchanged.
- **Hero** — reframed inside a tall heynox-style **`rounded-[24px]` card** (12px gutters, a *subtle* warm vermillion glow on warm-paper), content pinned left (badge → h1 → description → CTAs → install line), the existing **terminal + citation-chip demo card** on the right, and a capability **trust strip** (pinned bottom-left on desktop; framed in-flow with a hairline on mobile). The old flat stat-strip is removed.
- **Footer** — rebuilt as a superpower-style **rounded inset block** (matching 12px gutters) with the brand block + Product/Trust columns, an oversized low-contrast `ato-mcp` wordmark, and the in-block legal bar. Existing links retained.
- **Design system** — adds `.hero-card`, `.hero-glow`, `.footer-card` to `globals.css`, mirroring the existing `.card`/`.tile` pattern. No new dependencies; no palette change.

Scope: `packages/web` only (`app/globals.css`, `components/site/Nav.tsx`, `app/page.tsx`, `components/site/Footer.tsx`). Other page sections and the backend/auth/data layers are untouched.

## Test plan

- [x] `pnpm --filter @ato-mcp/web typecheck` — clean
- [x] `pnpm --filter @ato-mcp/web build` — succeeds (`/` prerenders static)
- [x] `pnpm --filter @ato-mcp/web test` — 3/3 pass
- [x] Playwright visual QA at desktop (1440) + mobile (390): nav order & no GitHub; hero card/glow/demo/trust strip; footer block/wordmark/links; no hydration errors
- [ ] Confirm the Vercel preview deploy renders as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)