### PR TITLE
Remove the v1.1 hero badge

### DIFF
--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -246,16 +246,9 @@ export default function HomePage() {
             <span className="hero-glow" aria-hidden="true" />
             <div className="relative grid w-full items-center gap-12 px-[clamp(28px,6vw,88px)] py-28 lg:grid-cols-[1.05fr_0.95fr] lg:py-24">
               <div>
-                <p
-                  className="reveal inline-flex items-center gap-2 rounded-full border border-black/5 bg-white px-3 py-1 font-mono text-[0.6875rem] uppercase tracking-[0.08em] text-zinc-500 shadow-[0_1px_2px_rgba(0,0,0,0.04)]"
-                  style={{ "--reveal-delay": "0s" } as React.CSSProperties}
-                >
-                  <span className="inline-block h-1.5 w-1.5 rounded-full bg-brand" />
-                  v1.1 · open source · MIT
-                </p>
                 <h1
-                  className="reveal mt-5 text-[clamp(2.5rem,5vw,3.5rem)] font-normal leading-[1.04] tracking-tight2 text-zinc-900"
-                  style={{ "--reveal-delay": "0.08s" } as React.CSSProperties}
+                  className="reveal text-[clamp(2.5rem,5vw,3.5rem)] font-normal leading-[1.04] tracking-tight2 text-zinc-900"
+                  style={{ "--reveal-delay": "0s" } as React.CSSProperties}
                 >
                   Your AI agent, fluent in Australian tax
                 </h1>


### PR DESCRIPTION
## Summary

Removes the `v1.1 · open source · MIT` pill badge from the top of the hero content column (`p.reveal.inline-flex.items-center.gap-2`). The heading now leads the content block — its orphaned `mt-5` top margin is dropped and its `reveal` delay reset to `0s` as the new first element.

Scope: `packages/web/app/page.tsx` only.

## Test plan

- [x] `pnpm --filter @ato-mcp/web typecheck` — clean
- [x] Playwright visual check (desktop 1440): badge gone, heading flush at top, no layout gap
- [ ] Confirm the Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)