### PR TITLE
Adopt pluck's footer layout

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -74,6 +74,10 @@ body {
   .footer-card {
     @apply rounded-[24px] border border-black/5 bg-zinc-50 shadow-[0_1px_2px_rgba(0,0,0,0.04),0_20px_50px_-28px_rgba(0,0,0,0.1)];
   }
+  /* --- Footer link: 14px, muted → ink on hover (pluck footer pattern) --- */
+  .footer-link {
+    @apply text-sm text-zinc-500 transition-colors hover:text-zinc-900;
+  }
 
   /* --- Citation chip: the one place the accent lives ------------------- */
   .chip {

--- a/packages/web/components/site/Footer.tsx
+++ b/packages/web/components/site/Footer.tsx
@@ -1,6 +1,13 @@
 import Link from "next/link";
 
-function Mark({ size = 22 }: { size?: number }) {
+const GITHUB = "https://github.com/william-laverty/ato-mcp";
+const NPM = "https://www.npmjs.com/package/ato-mcp";
+
+// MCP hosts ato-mcp connects to — shown as neutral pills in the brand group,
+// mirroring pluck's "Works with your agent" chip row.
+const AGENTS = ["Claude Code", "Claude Desktop", "Any MCP host"];
+
+function Mark({ size = 26 }: { size?: number }) {
   return (
     <svg
       width={size}
@@ -19,70 +26,91 @@ function Mark({ size = 22 }: { size?: number }) {
 export function Footer() {
   return (
     <footer className="px-3 pb-3">
-      <div className="footer-card px-6 pb-8 pt-14 text-zinc-500 sm:px-10">
+      <div className="footer-card overflow-hidden px-6 py-14 sm:px-10 sm:py-16 lg:px-16">
         <div className="mx-auto max-w-6xl">
-          <div className="grid gap-10 md:grid-cols-4">
-            <div className="md:col-span-2">
-              <div className="flex items-center gap-2">
-                <Mark />
-                <span className="text-[15px] font-medium tracking-tight1 text-zinc-900">
+          <div className="flex flex-col gap-12 lg:flex-row lg:justify-between lg:gap-16">
+            {/* Brand group */}
+            <div className="max-w-sm">
+              <div className="flex items-center gap-2.5">
+                <Mark size={26} />
+                <span className="text-[17px] font-medium tracking-tight1 text-zinc-900">
                   ato-mcp
                 </span>
               </div>
-              <p className="mt-3 max-w-sm text-sm leading-relaxed">
-                The Australian tax knowledge base for AI agents — cited retrieval,
-                personal context, and tax workflow tools over the Model Context
-                Protocol. Open source.
+              <p className="mt-5 text-[14.5px] leading-relaxed text-zinc-500">
+                <span className="font-medium text-zinc-900">
+                  Cited, current ATO retrieval.
+                </span>{" "}
+                Connect Claude — or any MCP agent — to 29,000+ ATO documents, the
+                ITAA 1997 and public rulings, with personal context and tax
+                workflow tools. Open source.
               </p>
-              <p className="mt-4 text-xs text-zinc-400">
+              <p className="mt-4 text-xs leading-relaxed text-zinc-400">
                 Information infrastructure, not tax advice. Verify material
                 decisions with a registered tax agent.
               </p>
+              <div className="mt-6">
+                <p className="eyebrow mb-3">Works with your agent</p>
+                <div className="flex flex-wrap gap-2">
+                  {AGENTS.map((a) => (
+                    <span
+                      key={a}
+                      className="inline-flex items-center rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs text-zinc-600"
+                    >
+                      {a}
+                    </span>
+                  ))}
+                </div>
+              </div>
             </div>
-            <nav aria-label="Product" className="text-sm">
-              <p className="eyebrow mb-3">Product</p>
-              <ul className="space-y-2">
-                <li><Link className="transition-colors hover:text-zinc-900" href="/docs">Documentation</Link></li>
-                <li><Link className="transition-colors hover:text-zinc-900" href="/onboard">Get started</Link></li>
-                <li><Link className="transition-colors hover:text-zinc-900" href="/account">Account</Link></li>
-                <li>
-                  <a className="transition-colors hover:text-zinc-900" href="https://github.com/william-laverty/ato-mcp" target="_blank" rel="noopener noreferrer">
-                    GitHub ↗
-                  </a>
-                </li>
-                <li>
-                  <a className="transition-colors hover:text-zinc-900" href="https://www.npmjs.com/package/ato-mcp" target="_blank" rel="noopener noreferrer">
-                    npm ↗
-                  </a>
-                </li>
-              </ul>
-            </nav>
-            <nav aria-label="Trust" className="text-sm">
-              <p className="eyebrow mb-3">Trust</p>
-              <ul className="space-y-2">
-                <li><Link className="transition-colors hover:text-zinc-900" href="/privacy">Privacy</Link></li>
-                <li><Link className="transition-colors hover:text-zinc-900" href="/terms">Terms</Link></li>
-                <li>
-                  <a className="transition-colors hover:text-zinc-900" href="https://github.com/william-laverty/ato-mcp/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">
-                    Security ↗
-                  </a>
-                </li>
-              </ul>
+
+            {/* Link grid */}
+            <nav
+              className="grid grid-cols-2 gap-x-10 gap-y-10 sm:grid-cols-3 lg:gap-x-16"
+              aria-label="Footer"
+            >
+              <div className="flex flex-col gap-3.5">
+                <p className="eyebrow">Product</p>
+                <Link className="footer-link" href="/docs">Documentation</Link>
+                <Link className="footer-link" href="/onboard">Get started</Link>
+                <Link className="footer-link" href="/account">Account</Link>
+              </div>
+              <div className="flex flex-col gap-3.5">
+                <p className="eyebrow">Open source</p>
+                <a className="footer-link" href={GITHUB} target="_blank" rel="noopener noreferrer">
+                  GitHub ↗
+                </a>
+                <a className="footer-link" href={NPM} target="_blank" rel="noopener noreferrer">
+                  npm ↗
+                </a>
+                <a className="footer-link" href={`${GITHUB}/releases`} target="_blank" rel="noopener noreferrer">
+                  Releases ↗
+                </a>
+              </div>
+              <div className="flex flex-col gap-3.5">
+                <p className="eyebrow">Legal</p>
+                <Link className="footer-link" href="/privacy">Privacy</Link>
+                <Link className="footer-link" href="/terms">Terms</Link>
+                <a className="footer-link" href={`${GITHUB}/blob/main/SECURITY.md`} target="_blank" rel="noopener noreferrer">
+                  Security ↗
+                </a>
+              </div>
             </nav>
           </div>
 
-          {/* Oversized wordmark — the one superpower-style flourish (decorative). */}
-          <p
-            className="mt-14 select-none text-[clamp(3.5rem,14vw,9rem)] font-medium leading-none tracking-tight2 text-zinc-200"
-            aria-hidden="true"
-          >
-            ato-mcp
-          </p>
-
-          {/* Legal bar */}
-          <div className="mt-10 flex flex-col gap-2 border-t border-zinc-200 pt-6 text-xs text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
-            <p>© {new Date().getFullYear()} William Laverty · MIT licensed</p>
-            <p>ATO content remains subject to ATO publication terms.</p>
+          {/* Bottom bar */}
+          <div className="mt-14 flex flex-col gap-4 border-t border-zinc-200 pt-7 text-[13px] text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <p>© {new Date().getFullYear()} William Laverty · MIT licensed</p>
+              <p>ATO content remains subject to ATO publication terms.</p>
+            </div>
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-2.5">
+              <Link className="footer-link" href="/privacy">Privacy</Link>
+              <Link className="footer-link" href="/terms">Terms</Link>
+              <a className="footer-link" href={GITHUB} target="_blank" rel="noopener noreferrer">
+                GitHub
+              </a>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Adapts our footer content into the layout used by the `pluck` project — same structure, our content + Clinical palette (zinc + vermillion, mono eyebrows).

- **Brand group (left):** logo, a bold-lead tagline ("Cited, current ATO retrieval."), the "information infrastructure, not tax advice" disclaimer, and a **"Works with your agent"** chip row (Claude Code · Claude Desktop · Any MCP host).
- **Link grid (right):** three columns — **Product** (Documentation, Get started, Account), **Open source** (GitHub ↗, npm ↗, Releases ↗), **Legal** (Privacy, Terms, Security ↗). Collapses to 2 columns on mobile.
- **Bottom bar:** copyright + ATO-publication-terms line, with a compact Privacy · Terms · GitHub link row.
- Drops the decorative oversized wordmark from the previous footer.
- Adds a `.footer-link` helper class (14px, muted → ink on hover) mirroring pluck's `.footer-link`.

Scope: `packages/web/components/site/Footer.tsx` + a one-class addition to `app/globals.css`. All previous footer links/content are preserved.

## Test plan

- [x] `pnpm --filter @ato-mcp/web typecheck` — clean
- [x] Playwright footer screenshots, desktop (1440) + mobile (390): brand left, 3-col grid right (2-col on mobile), chips, bottom bar — all correct
- [ ] Confirm the Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)