### PR TITLE
feat(web): cinematic corpus → MCP scroll section

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -149,3 +149,100 @@ body {
     animation: none !important;
   }
 }
+
+/* --- Corpus flow: sticky scrollytelling visual --------------------------- */
+.corpus-visual {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+.corpus-visual .cf-graph,
+.corpus-visual .cf-sources,
+.corpus-visual .cf-stats,
+.corpus-visual .cf-agent,
+.corpus-visual .cf-query {
+  transition:
+    opacity 0.7s var(--ease-out),
+    transform 0.7s var(--ease-out);
+}
+
+/* base = act 0 (sources) */
+.corpus-visual .cf-graph {
+  opacity: 0.18;
+}
+.corpus-visual .cf-stats {
+  opacity: 0;
+}
+.corpus-visual .cf-agent {
+  opacity: 0;
+  transform: translateY(10px);
+}
+.corpus-visual .cf-query {
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+/* act 1 = one library */
+.corpus-visual[data-step="1"] .cf-sources {
+  opacity: 0.3;
+  transform: translateX(-8px);
+}
+.corpus-visual[data-step="1"] .cf-graph {
+  opacity: 1;
+}
+.corpus-visual[data-step="1"] .cf-stats {
+  opacity: 1;
+}
+
+/* act 2 = connect */
+.corpus-visual[data-step="2"] .cf-sources {
+  opacity: 0.2;
+}
+.corpus-visual[data-step="2"] .cf-graph {
+  opacity: 0.7;
+}
+.corpus-visual[data-step="2"] .cf-agent {
+  opacity: 1;
+  transform: none;
+}
+
+/* act 3 = just ask */
+.corpus-visual[data-step="3"] .cf-sources {
+  opacity: 0.2;
+}
+.corpus-visual[data-step="3"] .cf-graph {
+  opacity: 0.7;
+}
+.corpus-visual[data-step="3"] .cf-query {
+  opacity: 1;
+  transform: none;
+}
+
+/* citation links draw themselves once the graph is shown */
+.corpus-visual .cf-link {
+  stroke-dasharray: 60;
+  stroke-dashoffset: 60;
+}
+.corpus-visual[data-step="1"] .cf-link,
+.corpus-visual[data-step="2"] .cf-link,
+.corpus-visual[data-step="3"] .cf-link {
+  animation: cfLinkDraw 0.9s var(--ease-out) forwards;
+}
+@keyframes cfLinkDraw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .corpus-visual .cf-graph,
+  .corpus-visual .cf-sources,
+  .corpus-visual .cf-stats,
+  .corpus-visual .cf-agent,
+  .corpus-visual .cf-query,
+  .corpus-visual .cf-link {
+    transition: none !important;
+    animation: none !important;
+    stroke-dashoffset: 0 !important;
+  }
+}

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Fragment } from "react";
 import Link from "next/link";
+import { CorpusFlow } from "../components/site/CorpusFlow";
 
 export const metadata: Metadata = {
   alternates: { canonical: "/" },
@@ -16,46 +17,6 @@ const HERO_TRUST = [
   { title: "Cited retrieval", sub: "every answer sourced" },
   { title: "29,000+ documents", sub: "refreshed monthly" },
   { title: "Any MCP host", sub: "Claude Code & Desktop" },
-];
-
-const CORPUS_STATS = [
-  { n: "224,585", label: "passages", sub: "every paragraph, searchable" },
-  { n: "4,638", label: "ITAA 1997 sections", sub: "+ 1,929 legal definitions" },
-  { n: "23,267", label: "citation links", sub: "rulings tied to legislation" },
-];
-
-const CORPUS_INDEX = [
-  { num: "01", title: "Guidance", sub: "ato.gov.au" },
-  { num: "02", title: "Legislation", sub: "ITAA 1997, in full" },
-  { num: "03", title: "Rulings", sub: "law.ato.gov.au" },
-  { num: "04", title: "Citation graph", sub: "everything cross-linked" },
-];
-
-const HOW_IT_WORKS = [
-  {
-    num: "1",
-    title: "Install",
-    body: "One global npm package.",
-    fragment: "npx -y ato-mcp",
-  },
-  {
-    num: "2",
-    title: "Onboard",
-    body: "Sign in with email, about two minutes.",
-    fragment: "ato-mcp.com.au/onboard",
-  },
-  {
-    num: "3",
-    title: "Connect",
-    body: "One line in your MCP host config.",
-    fragment: "claude mcp add ato-mcp",
-  },
-  {
-    num: "4",
-    title: "Ask",
-    body: "Answers arrive with their citations.",
-    fragment: "› what can I claim?",
-  },
 ];
 
 const FAQS = [
@@ -252,96 +213,8 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ------------------------------------------------ corpus */}
-      <section
-        className="mx-auto max-w-6xl px-5 py-20 sm:py-24"
-        aria-labelledby="corpus-h"
-      >
-        <div className="grid gap-12 lg:grid-cols-[1fr_260px]">
-          <div>
-            <p className="eyebrow">The corpus</p>
-            <h2
-              id="corpus-h"
-              className="mt-3 max-w-xl text-[clamp(1.6rem,3vw,2.25rem)] font-normal leading-[1.1] tracking-tight1"
-            >
-              The whole landscape, indexed — guidance, statute and rulings in
-              one graph
-            </h2>
-            <div className="mt-10 grid gap-4 sm:grid-cols-3">
-              {CORPUS_STATS.map((s) => (
-                <div key={s.label} className="card reveal-scroll p-5">
-                  <p className="text-[1.75rem] tracking-tight1 text-zinc-900">
-                    {s.n}
-                  </p>
-                  <p className="mt-1 text-sm font-medium">{s.label}</p>
-                  <p className="mt-1 text-xs text-zinc-400">{s.sub}</p>
-                </div>
-              ))}
-            </div>
-            <p className="mt-6 text-sm text-zinc-500">
-              Rebuilt monthly, served fresh.{" "}
-              <Link
-                href="/docs"
-                className="text-zinc-900 underline decoration-zinc-300 underline-offset-4 transition-colors hover:decoration-zinc-900"
-              >
-                See what&apos;s inside
-              </Link>
-            </p>
-          </div>
-          <div className="border-zinc-100 lg:border-l lg:pl-10">
-            <ol>
-              {CORPUS_INDEX.map((i, idx) => (
-                <li
-                  key={i.num}
-                  className={`flex items-baseline justify-between gap-4 py-4 ${
-                    idx < CORPUS_INDEX.length - 1 ? "border-b border-zinc-100" : ""
-                  }`}
-                >
-                  <div>
-                    <p className="text-sm font-medium text-zinc-900">{i.title}</p>
-                    <p className="mt-0.5 text-xs text-zinc-400">{i.sub}</p>
-                  </div>
-                  <span className="font-mono text-[0.6875rem] text-zinc-400">
-                    {i.num}
-                  </span>
-                </li>
-              ))}
-            </ol>
-          </div>
-        </div>
-      </section>
-
-      {/* ------------------------------------------------ how it works */}
-      <section className="mx-auto max-w-6xl px-5 pb-20 sm:pb-24" aria-labelledby="how-h">
-        <div className="text-center">
-          <p className="eyebrow">How it works</p>
-          <h2
-            id="how-h"
-            className="mt-3 text-[clamp(1.6rem,3vw,2.25rem)] font-normal leading-[1.1] tracking-tight1"
-          >
-            From npm to a tax-fluent agent in two minutes
-          </h2>
-        </div>
-        <div className="mt-12 grid gap-x-4 gap-y-8 sm:grid-cols-2 lg:grid-cols-4">
-          {HOW_IT_WORKS.map((s) => (
-            <div key={s.num} className="reveal-scroll">
-              {/* Visual-first tile (superpower image-card pattern), caption below */}
-              <div className="tile flex h-36 items-center justify-center px-5">
-                <span className="absolute left-3 top-3 flex h-6 w-6 items-center justify-center rounded-full bg-white font-mono text-[0.6875rem] text-zinc-500 shadow-[0_1px_3px_rgba(0,0,0,0.08)]">
-                  {s.num}
-                </span>
-                <p className="overflow-x-auto whitespace-nowrap font-mono text-xs text-zinc-700">
-                  {s.fragment}
-                </p>
-              </div>
-              <h3 className="mt-4 text-base font-medium tracking-tight1">
-                {s.title}
-              </h3>
-              <p className="mt-1 text-sm text-zinc-500">{s.body}</p>
-            </div>
-          ))}
-        </div>
-      </section>
+      {/* ------------------------------------------------ corpus → mcp flow */}
+      <CorpusFlow />
 
       {/* ------------------------------------------------ FAQ */}
       <section className="mx-auto max-w-3xl px-5 pb-24" aria-labelledby="faq-h">

--- a/packages/web/components/site/CorpusFlow.tsx
+++ b/packages/web/components/site/CorpusFlow.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Stat = { value: number; display: string; label: string };
+type Act = {
+  num: string;
+  kicker: string;
+  body: string;
+  sources?: readonly string[];
+  stats?: readonly Stat[];
+  fragment?: string;
+  chips?: readonly string[];
+};
+
+const ACTS: readonly Act[] = [
+  {
+    num: "01",
+    kicker: "Sources",
+    body: "Everything the ATO publishes, in one place — its website guidance, the Income Tax Act itself, and its official rulings.",
+    sources: ["ATO website", "Income Tax Act", "Public rulings"],
+  },
+  {
+    num: "02",
+    kicker: "One library",
+    body: "Brought together and cross-linked, so every ruling points back to the law behind it.",
+    stats: [
+      { value: 224585, display: "224,585", label: "searchable passages" },
+      { value: 4638, display: "4,638", label: "Income Tax Act sections" },
+      { value: 23267, display: "23,267", label: "citation links" },
+    ],
+  },
+  {
+    num: "03",
+    kicker: "Connect",
+    body: "Plug it into Claude — or any AI agent — with a single line, and tell it a little about your situation.",
+    fragment: "npx -y ato-mcp",
+  },
+  {
+    num: "04",
+    kicker: "Just ask",
+    body: "Ask in plain English. Your agent answers from the library and shows the exact sources behind every line.",
+    chips: ["ITAA s 8-1", "TR 93/30", "PCG 2023/1"],
+  },
+];
+
+export function useReducedMotion() {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener?.("change", update);
+    return () => mq.removeEventListener?.("change", update);
+  }, []);
+  return reduced;
+}
+
+export function useCountUp(target: number, run: boolean, reduced: boolean) {
+  const [val, setVal] = useState(target); // SSR + first client render = final (no hydration mismatch)
+  const started = useRef(false);
+  useEffect(() => {
+    if (!run || reduced || started.current) return;
+    started.current = true;
+    const duration = 1100;
+    let raf = 0;
+    let start = 0;
+    setVal(0);
+    const tick = (t: number) => {
+      if (!start) start = t;
+      const p = Math.min(1, (t - start) / duration);
+      const eased = 1 - Math.pow(1 - p, 3);
+      setVal(Math.round(target * eased));
+      if (p < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [run, reduced, target]);
+  return val;
+}
+
+function StepProof({ act }: { act: Act }) {
+  if (act.sources) {
+    return (
+      <ul className="mt-4 flex flex-wrap gap-2">
+        {act.sources.map((s) => (
+          <li key={s} className="badge">
+            {s}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+  if (act.stats) {
+    return (
+      <dl className="mt-5 grid max-w-md grid-cols-3 gap-4">
+        {act.stats.map((s) => (
+          <div key={s.label}>
+            <dt className="text-[1.5rem] leading-none tracking-tight1 text-zinc-900">
+              <span>{s.display}</span>
+            </dt>
+            <dd className="mt-1.5 text-xs text-zinc-400">{s.label}</dd>
+          </div>
+        ))}
+      </dl>
+    );
+  }
+  if (act.fragment) {
+    return <p className="code-block mt-4 inline-block">{act.fragment}</p>;
+  }
+  if (act.chips) {
+    return (
+      <div className="mt-4 flex flex-wrap gap-1.5">
+        {act.chips.map((c) => (
+          <span key={c} className="chip">
+            <span className="chip-dot" />
+            {c}
+          </span>
+        ))}
+      </div>
+    );
+  }
+  return null;
+}
+
+export function CorpusVisual({ step }: { step: number }) {
+  const reduced = useReducedMotion();
+  const stats = ACTS[1]!.stats!;
+  const counts = [
+    useCountUp(stats[0]!.value, step >= 1, reduced),
+    useCountUp(stats[1]!.value, step >= 1, reduced),
+    useCountUp(stats[2]!.value, step >= 1, reduced),
+  ];
+
+  return (
+    <div className="corpus-visual" data-step={step} aria-hidden="true">
+      {/* citation graph */}
+      <svg
+        className="cf-graph absolute inset-0 h-full w-full"
+        viewBox="0 0 100 100"
+        fill="none"
+        preserveAspectRatio="xMidYMid meet"
+      >
+        <g stroke="#e4e4e7" strokeWidth="0.5">
+          <path className="cf-link" d="M30 30 L52 44" />
+          <path className="cf-link" d="M52 44 L74 32" />
+          <path className="cf-link" d="M52 44 L70 64" />
+          <path className="cf-link" d="M30 66 L52 44" />
+          <path className="cf-link" d="M70 64 L74 32" />
+        </g>
+        <g>
+          <circle cx="30" cy="30" r="1.6" fill="#d4d4d8" />
+          <circle cx="52" cy="44" r="2.2" fill="#fa520f" opacity="0.55" />
+          <circle cx="74" cy="32" r="1.6" fill="#d4d4d8" />
+          <circle cx="70" cy="64" r="1.6" fill="#d4d4d8" />
+          <circle cx="30" cy="66" r="1.6" fill="#d4d4d8" />
+        </g>
+      </svg>
+
+      {/* act 0 — sources */}
+      <div className="cf-sources absolute left-6 top-1/2 -translate-y-1/2 space-y-3">
+        {ACTS[0]!.sources!.map((s) => (
+          <div key={s} className="flex items-center gap-2">
+            <span className="h-1.5 w-1.5 rounded-full bg-brand" />
+            <span className="font-mono text-[0.6875rem] text-zinc-500">{s}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* act 1 — counting stats */}
+      <div className="cf-stats absolute inset-0 flex flex-col items-center justify-center gap-4 text-center">
+        {stats.map((s, i) => (
+          <div key={s.label}>
+            <div
+              className="text-[1.75rem] leading-none tracking-tight1 text-zinc-900"
+              suppressHydrationWarning
+            >
+              {counts[i]!.toLocaleString("en-AU")}
+            </div>
+            <div className="mt-1 font-mono text-[0.625rem] uppercase tracking-[0.08em] text-zinc-400">
+              {s.label}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* act 2 — connect */}
+      <div className="cf-agent absolute bottom-8 left-1/2 -translate-x-1/2">
+        <div className="card px-3 py-2 font-mono text-[0.6875rem] text-zinc-600">
+          npx -y ato-mcp
+        </div>
+      </div>
+
+      {/* act 3 — query + citations */}
+      <div className="cf-query absolute inset-x-6 bottom-8">
+        <div className="card p-3 text-left">
+          <p className="font-mono text-[0.6875rem] text-zinc-400">
+            › what can I claim?
+          </p>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {ACTS[3]!.chips!.map((c) => (
+              <span key={c} className="chip">
+                <span className="chip-dot" />
+                {c}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function CorpusFlow() {
+  const [active, setActive] = useState(0);
+  const refs = useRef<(HTMLLIElement | null)[]>([]);
+
+  useEffect(() => {
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            setActive(Number((e.target as HTMLElement).dataset.index));
+          }
+        }
+      },
+      { rootMargin: "-45% 0px -45% 0px", threshold: 0 },
+    );
+    refs.current.forEach((el) => el && obs.observe(el));
+    return () => obs.disconnect();
+  }, []);
+
+  return (
+    <section
+      className="mx-auto max-w-6xl px-5 py-20 sm:py-24"
+      aria-labelledby="flow-h"
+    >
+      <div className="text-center">
+        <p className="eyebrow">How it works</p>
+        <h2
+          id="flow-h"
+          className="mx-auto mt-3 max-w-2xl text-[clamp(1.6rem,3vw,2.25rem)] font-normal leading-[1.1] tracking-tight1"
+        >
+          Every word the ATO publishes — one question away
+        </h2>
+      </div>
+
+      <div className="mt-12 grid gap-10 lg:mt-16 lg:grid-cols-2 lg:gap-16">
+        {/* sticky visual (desktop only) */}
+        <div className="hidden lg:block">
+          <div className="sticky top-0 flex h-screen items-center">
+            <div className="tile aspect-square w-full">
+              <CorpusVisual step={active} />
+            </div>
+          </div>
+        </div>
+
+        {/* scrolling steps */}
+        <ol data-testid="corpus-flow-steps" className="space-y-12 lg:space-y-0">
+          {ACTS.map((act, i) => (
+            <li
+              key={act.num}
+              data-index={i}
+              ref={(el) => {
+                refs.current[i] = el;
+              }}
+              className="reveal-scroll lg:flex lg:min-h-screen lg:flex-col lg:justify-center"
+            >
+              <p className="eyebrow">
+                {act.num} · {act.kicker}
+              </p>
+              <p className="mt-3 max-w-md text-[15px] leading-relaxed text-zinc-600">
+                {act.body}
+              </p>
+              <StepProof act={act} />
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/test/corpus-flow.test.tsx
+++ b/packages/web/test/corpus-flow.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { render, within } from "@testing-library/react";
+import React from "react";
+import { CorpusFlow } from "@/components/site/CorpusFlow";
+
+describe("CorpusFlow", () => {
+  it("renders all four acts' copy in the steps region", () => {
+    const steps = within(render(<CorpusFlow />).getByTestId("corpus-flow-steps"));
+    expect(steps.getByText(/Everything the ATO publishes/)).toBeInTheDocument();
+    expect(steps.getByText(/Brought together and cross-linked/)).toBeInTheDocument();
+    expect(steps.getByText(/Plug it into Claude/)).toBeInTheDocument();
+    expect(steps.getByText(/Ask in plain English/)).toBeInTheDocument();
+  });
+
+  it("renders the corpus numbers as static step text", () => {
+    const steps = within(render(<CorpusFlow />).getByTestId("corpus-flow-steps"));
+    expect(steps.getByText("224,585")).toBeInTheDocument();
+    expect(steps.getByText("4,638")).toBeInTheDocument();
+    expect(steps.getByText("23,267")).toBeInTheDocument();
+  });
+
+  it("renders the connect fragment and citation chips", () => {
+    const steps = within(render(<CorpusFlow />).getByTestId("corpus-flow-steps"));
+    expect(steps.getByText("npx -y ato-mcp")).toBeInTheDocument();
+    expect(steps.getByText("ITAA s 8-1")).toBeInTheDocument();
+    expect(steps.getByText("TR 93/30")).toBeInTheDocument();
+  });
+
+  it("marks the decorative visual aria-hidden", () => {
+    const { container } = render(<CorpusFlow />);
+    const visual = container.querySelector(".corpus-visual");
+    expect(visual).not.toBeNull();
+    expect(visual?.getAttribute("aria-hidden")).toBe("true");
+  });
+});

--- a/packages/web/test/setup.ts
+++ b/packages/web/test/setup.ts
@@ -1,1 +1,29 @@
 import "@testing-library/jest-dom";
+
+// jsdom lacks IntersectionObserver — stub it so components that observe on mount render.
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [] as IntersectionObserverEntry[];
+  }
+}
+globalThis.IntersectionObserver =
+  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+// jsdom lacks matchMedia — default to "no preference" (motion enabled).
+if (typeof window !== "undefined" && !window.matchMedia) {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+    dispatchEvent() {
+      return false;
+    },
+  })) as unknown as typeof window.matchMedia;
+}

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
   test: {
     environment: "jsdom",
     setupFiles: ["./test/setup.ts"],


### PR DESCRIPTION
## Summary
Replaces the two static landing sections ("The corpus" and "How it works") with one cinematic, scroll-driven section — `CorpusFlow` — that takes the visitor from raw ATO sources → one searchable library → connecting their agent → cited answers.

On `lg+`, a decorative SVG visual **pins** while four step-blocks scroll past on the right; a single `IntersectionObserver` tracks the active step and the visual cross-fades between four acts via CSS keyed on `data-step`. The corpus numbers count up. No scroll-jacking, no animation library — pure CSS motion consistent with the existing `reveal`/`reveal-scroll` pattern.

**Acts:** `01 · Sources` → `02 · One library` (224,585 passages · 4,638 ITAA sections · 23,267 citation links, counting up) → `03 · Connect` (`npx -y ato-mcp`) → `04 · Just ask` (citation chips).

New section order: **hero → CorpusFlow → FAQ → final CTA**.

## Implementation
- `components/site/CorpusFlow.tsx` — `ACTS` data, `useReducedMotion`/`useCountUp` hooks, `StepProof`, `CorpusVisual`, and the `CorpusFlow` section (sticky visual + scrolling steps + observer).
- `app/globals.css` — per-act cross-fade states, citation link-draw, reduced-motion guard.
- `app/page.tsx` — swap both sections for `<CorpusFlow />`; remove the now-dead `CORPUS_STATS` / `CORPUS_INDEX` / `HOW_IT_WORKS` constants.
- `test/corpus-flow.test.tsx` + `test/setup.ts` (jsdom `IntersectionObserver`/`matchMedia` stubs); `vitest.config.ts` gets `esbuild.jsx: "automatic"`.

## Accessibility & fallbacks
- SVG visual is `aria-hidden`; all narrative copy, numbers, the connect fragment, and citation labels are real DOM text in the steps list.
- Mobile (< lg): visual hidden, steps stack with `reveal-scroll`.
- No-JS / Firefox / SSR: all content renders; visual shows final state.
- `prefers-reduced-motion`: count-up and transitions disabled (JS + CSS).

## Verification
- `pnpm --filter @ato-mcp/web typecheck` clean; `pnpm --filter @ato-mcp/web test` 7/7; production build succeeds.
- Visual QA via Playwright scroll-capture confirmed all four acts render and the visual transitions `data-step` 0→3 (numbers count up mid-scroll).
- Reviewed task-by-task plus a whole-branch review (verdict: ready to merge, no critical/important issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)