### PR TITLE
feat(web): pluck-style navbar morph + seamless CTA→footer

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -70,6 +70,19 @@ body {
     );
   }
 
+  /* --- Closing CTA atmosphere ------------------------------------------
+     A faint vermillion wash bleeding down from the top of the final CTA, on
+     plain white (no solid band). It melts the CTA into the page so the
+     floating footer card below reads as an inset panel overlaying the
+     extended bottom of the CTA — not a hard-cut colour block. */
+  .glow-cta {
+    background: radial-gradient(
+      62% 58% at 50% -4%,
+      rgba(250, 82, 15, 0.06) 0%,
+      transparent 68%
+    );
+  }
+
   /* --- Footer card: rounded inset block (superpower section_footer3) ---- */
   .footer-card {
     @apply rounded-[24px] border border-black/5 bg-zinc-50 shadow-[0_1px_2px_rgba(0,0,0,0.04),0_20px_50px_-28px_rgba(0,0,0,0.1)];

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -585,10 +585,25 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ------------------------------------------------ final CTA */}
-      <section className="border-t border-zinc-100 bg-zinc-50">
-        <div className="mx-auto max-w-2xl px-5 py-20 text-center sm:py-24">
-          <h2 className="text-[clamp(1.65rem,6vw,2.5rem)] font-normal leading-[1.1] tracking-tight2 text-zinc-900">
+      {/* ------------------------------------------------ final CTA
+          On plain white with a faint glow + deep bottom padding so it melts
+          into the page; the floating footer card below then reads as an inset
+          panel overlaying the extended bottom of the CTA (pluck pattern). */}
+      <section className="glow-cta px-5 pt-20 pb-28 sm:pt-24">
+        <div className="mx-auto max-w-2xl text-center">
+          <svg
+            width={48}
+            height={48}
+            viewBox="0 0 32 32"
+            fill="none"
+            aria-hidden="true"
+            className="mx-auto"
+          >
+            <rect x="1" y="1" width="30" height="30" rx="8.5" fill="#fa520f" />
+            <circle cx="10.5" cy="16" r="2.6" fill="#ffffff" />
+            <rect x="15" y="13.9" width="7.5" height="4.2" rx="2.1" fill="#ffffff" />
+          </svg>
+          <h2 className="mt-7 text-[clamp(1.65rem,6vw,2.5rem)] font-normal leading-[1.1] tracking-tight2 text-zinc-900">
             Two minutes to a tax-fluent agent
           </h2>
           <p className="mt-4 text-[15px] text-zinc-500">

--- a/packages/web/components/site/Nav.tsx
+++ b/packages/web/components/site/Nav.tsx
@@ -71,27 +71,22 @@ export function Nav() {
   const pillPainted = scrolled || open;
 
   return (
-    <header
-      className={[
-        "fixed inset-x-0 top-0 z-50 px-4 transition-[padding] duration-500 ease-out",
-        scrolled ? "py-3" : "py-4",
-      ].join(" ")}
-    >
+    <header className="fixed inset-x-0 top-0 z-50 px-6 pt-[30px] max-md:px-4 max-md:pt-4">
       <div
         className={[
-          "mx-auto transition-[max-width] duration-500 ease-out will-change-[max-width]",
-          scrolled ? "max-w-3xl" : "max-w-6xl",
+          "mx-auto transition-[max-width] duration-[550ms] ease-[cubic-bezier(0.16,1,0.3,1)] will-change-[max-width]",
+          scrolled ? "max-w-[760px]" : "max-w-6xl",
         ].join(" ")}
       >
         {/* Nav pill — logo | links | CTA. Transparent at top, glass on scroll. */}
         <nav
           aria-label="Main"
           className={[
-            "grid grid-cols-[1fr_auto_1fr] items-center rounded-full border px-2 py-1.5 transition-[background-color,border-color,box-shadow,backdrop-filter] duration-500 ease-out",
+            "grid grid-cols-[1fr_auto_1fr] items-center rounded-full border py-2 pl-3 pr-2 transition-[background-color,border-color,box-shadow,backdrop-filter] duration-[400ms] ease-[cubic-bezier(0.4,0,0.2,1)]",
             "max-md:flex max-md:flex-col max-md:items-stretch max-md:gap-0 max-md:rounded-2xl max-md:px-3 max-md:py-1.5",
             pillPainted
-              ? "border-black/5 bg-white/80 shadow-[0_4px_24px_rgba(0,0,0,0.08)] backdrop-blur-xl"
-              : "border-transparent bg-transparent max-md:border-black/5 max-md:bg-white/80 max-md:shadow-[0_4px_24px_rgba(0,0,0,0.08)] max-md:backdrop-blur-xl",
+              ? "border-black/[0.06] bg-white/80 shadow-[0_14px_40px_-18px_rgba(24,24,27,0.18),inset_0_1px_0_rgba(255,255,255,0.7)] backdrop-blur-[20px] backdrop-saturate-150"
+              : "border-transparent bg-transparent max-md:border-black/[0.06] max-md:bg-white/80 max-md:shadow-[0_14px_40px_-18px_rgba(24,24,27,0.18),inset_0_1px_0_rgba(255,255,255,0.7)] max-md:backdrop-blur-[20px] max-md:backdrop-saturate-150",
           ].join(" ")}
         >
           {/* Top row: contents on desktop so the grid owns layout; flex row on mobile. */}


### PR DESCRIPTION
## Change Summary
Refined the landing page chrome to match the pluck site's polish. The navbar now holds a fixed position and morphs cleanly into a centred floating glass pill on scroll instead of bobbing vertically, and the closing CTA melts into the page so the footer card reads as a single layered panel rather than colliding with a hard-cut colour band.

### Changes
- Pinned the navbar to a constant `30px` top offset so it no longer shifts vertically on scroll — only its width and glass treatment animate.
- Tuned the scroll morph to pluck's settle easing (`cubic-bezier(0.16,1,0.3,1)`), collapsing from full width to a centred `760px` pill.
- Upgraded the scrolled-pill glass to a deeper soft shadow with an inset top highlight and `backdrop-blur(20px) saturate(150%)` for a more realistic frosted look.
- Replaced the final CTA's full-bleed zinc band (and its hard top border) with a white section carrying a faint vermillion glow wash, generous bottom padding, and the logo mark as a closing flourish.
- Added a `.glow-cta` atmosphere class so the CTA blends into white and the floating footer card overlays its extended bottom seamlessly.
- Kept all existing navbar content and the mobile pill/hamburger behaviour unchanged.