### PR TITLE
chore: drop dead onboard_sessions table + unused StatsInputSchema

### DIFF
--- a/packages/backend/migrations/0008_drop_onboard_sessions.sql
+++ b/packages/backend/migrations/0008_drop_onboard_sessions.sql
@@ -1,0 +1,11 @@
+-- 0008_drop_onboard_sessions.sql
+-- The CLI onboard-poll handshake was removed (v1.1.0): the CLI no longer
+-- generates a code, and nothing reads or writes onboard_sessions. The web
+-- onboarding flow uses magic-link auth + /api/poll → mcp_connections.last_seen_at
+-- instead. Migration 0007 already dropped the dead `mode` column; this drops
+-- the now-fully-orphaned table.
+--
+-- CASCADE removes the dependent index (onboard_sessions_user_id_idx) and RLS
+-- policy (onboard_deny_all). IF EXISTS keeps this idempotent and safe to re-run.
+
+DROP TABLE IF EXISTS onboard_sessions CASCADE;

--- a/packages/shared/src/tools.ts
+++ b/packages/shared/src/tools.ts
@@ -27,8 +27,6 @@ export const FetchInputSchema = z.object({
 
 export type FetchInput = z.infer<typeof FetchInputSchema>;
 
-export const StatsInputSchema = z.object({}).optional();
-
 export const GetDefinitionInputSchema = z.object({
   term: z.string().min(1),
   pit: z.string().optional(),


### PR DESCRIPTION
## What

Two inert leftovers from the v1.1.0 hosted-only migration, removed as cleanup.

### 1. `onboard_sessions` table → dropped (migration `0008`)
The CLI onboard-poll handshake was removed in v1.1.0. Nothing reads or writes this table anywhere in backend or web code — only a `deny_all` RLS policy referenced it. Migration `0007` had already dropped its dead `mode` column; this drops the now-fully-orphaned table.

- `DROP TABLE IF EXISTS onboard_sessions CASCADE` — idempotent, also clears the dependent index (`onboard_sessions_user_id_idx`) and RLS policy (`onboard_deny_all`).

> Note: `runOnboard()` (the `ato-mcp onboard` CLI command that opens the browser) is **unrelated and stays** — only the *poll* flow + its table are dead.

### 2. `StatsInputSchema` → deleted (`@ato-mcp/shared`)
An exported Zod schema nothing imports (grep-confirmed: referenced only in its own definition). The `stats` tool takes no args.

## Verification
- `pnpm -r typecheck` — green
- Full test suite — green (177 shared / 54 backend / 51 mcp / 3 web)
- No behaviour change.

## Deploy note
Migration `0008` still needs to be **applied to Supabase** after merge (drops an empty, unused table — safe and idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)