### PR TITLE
web: add Google Analytics 4 (gtag.js)

### DIFF
--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import localFont from "next/font/local";
 import { Geist_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
@@ -24,6 +25,9 @@ const mono = Geist_Mono({
 });
 
 const SITE = "https://ato-mcp.com.au";
+
+// Google Analytics 4 (gtag.js) measurement ID.
+const GA_MEASUREMENT_ID = "G-1DFRLLC2CR";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE),
@@ -99,6 +103,19 @@ export default function RootLayout({
   return (
     <html lang="en-AU" className={`${sans.variable} ${mono.variable}`}>
       <body className="min-h-screen bg-white font-sans text-zinc-900 antialiased">
+        {/* Google tag (gtag.js) */}
+        <Script
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_MEASUREMENT_ID}');
+          `}
+        </Script>
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}


### PR DESCRIPTION
Adds the Google Analytics 4 tag (`gtag.js`, measurement ID `G-1DFRLLC2CR`) to the website so it loads on every page.

## Approach
- Loaded via `next/script` with `strategy="afterInteractive"` in the root layout (`packages/web/app/layout.tsx`) — the App Router-correct way to load gtag; doesn't block first paint.
- Measurement ID lives in a single `GA_MEASUREMENT_ID` constant referenced by both the loader and the config script.
- Zero new dependencies. Runs alongside the existing `@vercel/analytics`.

## Verification
- `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)