### PR TITLE
OpenAI embeddings (additive, flagged off)

### DIFF
--- a/packages/backend/api/[tool].ts
+++ b/packages/backend/api/[tool].ts
@@ -28,7 +28,7 @@ import {
   AuditRiskCheckInputSchema,
   UserFactsSchema,
 } from "@ato-mcp/shared";
-import type { UserFacts } from "@ato-mcp/shared";
+import type { UserFacts, Embedder } from "@ato-mcp/shared";
 import { stats } from "@ato-mcp/shared/tools/stats";
 import { search } from "@ato-mcp/shared/tools/search";
 import { getChunks } from "@ato-mcp/shared/tools/get_chunks";
@@ -44,14 +44,18 @@ import { basPrepChecklist } from "@ato-mcp/shared/tools/bas_prep_checklist";
 import { auditRiskCheck } from "@ato-mcp/shared/tools/audit_risk_check";
 import { SupabaseStore } from "../src/supabase-store.js";
 import { WasmEmbedder } from "../src/wasm-embedder.js";
+import { OpenAIEmbedder } from "../src/openai-embedder.js";
+import { embedProvider } from "../src/embed-provider.js";
 import { makeServiceClient } from "../src/supabase.js";
 
 const store = new SupabaseStore();
 // The embedder downloads its model on first use — load it lazily and only for
 // tools that actually embed, so stats/get_chunks/etc. stay fast on cold start.
-let embedder: WasmEmbedder | null = null;
-async function getEmbedder(): Promise<WasmEmbedder> {
-  embedder ??= await WasmEmbedder.load();
+let embedder: Embedder | null = null;
+async function getEmbedder(): Promise<Embedder> {
+  embedder ??= embedProvider() === "openai"
+    ? await OpenAIEmbedder.load()
+    : await WasmEmbedder.load();
   return embedder;
 }
 

--- a/packages/backend/eval/run-eval.ts
+++ b/packages/backend/eval/run-eval.ts
@@ -3,6 +3,8 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { SupabaseStore } from "../src/supabase-store.js";
 import { WasmEmbedder } from "../src/wasm-embedder.js";
+import { OpenAIEmbedder } from "../src/openai-embedder.js";
+import { embedProvider } from "../src/embed-provider.js";
 import { loadGolden } from "./golden-schema.js";
 import { runCase, type CaseResult } from "./runner.js";
 import { scoreResults, diffBaseline, formatTable, type Baseline } from "./report.js";
@@ -15,6 +17,11 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  if (embedProvider() === "openai" && !process.env["OPENAI_API_KEY"]) {
+    console.error("EMBED_PROVIDER=openai but OPENAI_API_KEY is not set.");
+    process.exit(2);
+  }
+
   const argv = process.argv.slice(2);
   const updateBaseline = argv.includes("--update-baseline");
   const kArg = argv.find((a) => a.startsWith("--k="));
@@ -23,7 +30,8 @@ async function main(): Promise<void> {
 
   const golden = loadGolden(join(here, "golden.json"));
   const store = new SupabaseStore();
-  const embedder = await WasmEmbedder.load();
+  const embedder =
+    embedProvider() === "openai" ? await OpenAIEmbedder.load() : await WasmEmbedder.load();
 
   const results: CaseResult[] = [];
   for (const c of golden) {

--- a/packages/backend/src/embed-provider.ts
+++ b/packages/backend/src/embed-provider.ts
@@ -1,0 +1,11 @@
+// Single source of truth for the embedding provider flag. Default 'minilm'
+// keeps current behaviour; 'openai' switches query embedding + the vector RPC.
+export type EmbedProvider = "minilm" | "openai";
+
+export function embedProvider(): EmbedProvider {
+  return process.env["EMBED_PROVIDER"] === "openai" ? "openai" : "minilm";
+}
+
+export function vectorSearchRpc(): string {
+  return embedProvider() === "openai" ? "ato_vector_search_openai" : "ato_vector_search";
+}

--- a/packages/backend/src/openai-embedder.ts
+++ b/packages/backend/src/openai-embedder.ts
@@ -1,0 +1,60 @@
+// OpenAIEmbedder — query-time embedding via the OpenAI embeddings API.
+// Model + dims come from env so the serving source doesn't hardcode the choice.
+// MOCK_SUPABASE=1 returns a zero vector (no network) for tests.
+
+import type { Embedder } from "@ato-mcp/shared";
+
+const DEFAULT_MODEL = "text-embedding-3-large";
+const DEFAULT_DIMS = 3072;
+
+let cached: OpenAIEmbedder | null = null;
+
+export class OpenAIEmbedder implements Embedder {
+  private readonly apiKey: string | null;
+  private readonly model: string;
+  private readonly dims: number;
+  private readonly mock: boolean;
+
+  private constructor(apiKey: string | null, model: string, dims: number, mock: boolean) {
+    this.apiKey = apiKey;
+    this.model = model;
+    this.dims = dims;
+    this.mock = mock;
+  }
+
+  static async load(): Promise<OpenAIEmbedder> {
+    const model = process.env["OPENAI_EMBED_MODEL"] ?? DEFAULT_MODEL;
+    const dims = Number(process.env["OPENAI_EMBED_DIMS"] ?? DEFAULT_DIMS);
+    if (cached && cached.model === model && cached.dims === dims) return cached;
+
+    if (process.env["MOCK_SUPABASE"] === "1") {
+      cached = new OpenAIEmbedder(null, model, dims, true);
+      return cached;
+    }
+    const apiKey = process.env["OPENAI_API_KEY"];
+    if (!apiKey) throw new Error("OPENAI_API_KEY is not set");
+    cached = new OpenAIEmbedder(apiKey, model, dims, false);
+    return cached;
+  }
+
+  async embed(text: string): Promise<Float32Array> {
+    if (this.mock) return new Float32Array(this.dims);
+    const res = await fetch("https://api.openai.com/v1/embeddings", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model: this.model, input: text, dimensions: this.dims }),
+    });
+    if (!res.ok) {
+      throw new Error(`OpenAI embeddings ${res.status}: ${await res.text()}`);
+    }
+    const json = (await res.json()) as { data: Array<{ embedding: number[] }> };
+    return new Float32Array(json.data[0]!.embedding);
+  }
+
+  get name(): string {
+    return this.model;
+  }
+}

--- a/packages/backend/src/supabase-store.ts
+++ b/packages/backend/src/supabase-store.ts
@@ -11,6 +11,7 @@ import type {
 } from "@ato-mcp/shared";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { makeServiceClient } from "./supabase.js";
+import { vectorSearchRpc } from "./embed-provider.js";
 
 // ---------------------------------------------------------------------------
 // SupabaseStore — implements the shared Store interface against Supabase Postgres.
@@ -66,7 +67,7 @@ export class SupabaseStore implements Store {
   // vectorSearch
   // -------------------------------------------------------------------------
   async vectorSearch(vector: Float32Array, k: number, pit?: string): Promise<SearchHit[]> {
-    const { data, error } = await this.sb.rpc("ato_vector_search", {
+    const { data, error } = await this.sb.rpc(vectorSearchRpc(), {
       q_embedding: Array.from(vector),
       k,
       pit_date: pit ?? null,

--- a/packages/backend/test/openai-embedder.test.ts
+++ b/packages/backend/test/openai-embedder.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { OpenAIEmbedder } from "../src/openai-embedder.js";
+
+beforeAll(() => { process.env["MOCK_SUPABASE"] = "1"; });
+
+describe("OpenAIEmbedder (mock mode)", () => {
+  it("returns a zero vector of the configured dimension without network", async () => {
+    const e = await OpenAIEmbedder.load();
+    const v = await e.embed("working from home");
+    expect(v).toBeInstanceOf(Float32Array);
+    expect(v.length).toBe(3072);
+  });
+
+  it("honours OPENAI_EMBED_DIMS", async () => {
+    process.env["OPENAI_EMBED_DIMS"] = "1536";
+    const e = await OpenAIEmbedder.load();
+    expect((await e.embed("x")).length).toBe(1536);
+    delete process.env["OPENAI_EMBED_DIMS"];
+  });
+
+  it("exposes a model name", async () => {
+    const e = await OpenAIEmbedder.load();
+    expect(typeof e.name).toBe("string");
+  });
+});

--- a/packages/backend/test/supabase-store.test.ts
+++ b/packages/backend/test/supabase-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { SupabaseStore } from "../src/supabase-store.js";
 
@@ -260,5 +260,34 @@ describe("SupabaseStore.close()", () => {
     const { client } = makeMockClient();
     const store = new SupabaseStore(client);
     expect(() => store.close()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// vector RPC selection
+// ---------------------------------------------------------------------------
+describe("SupabaseStore vector RPC selection", () => {
+  afterEach(() => { delete process.env["EMBED_PROVIDER"]; });
+
+  function spyClient() {
+    const calls: string[] = [];
+    const client = {
+      rpc: (name: string) => { calls.push(name); return Promise.resolve({ data: [], error: null }); },
+      from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null, error: null }) }) }) }),
+    } as unknown as import("@supabase/supabase-js").SupabaseClient;
+    return { client, calls };
+  }
+
+  it("uses ato_vector_search by default", async () => {
+    const { client, calls } = spyClient();
+    await new SupabaseStore(client).vectorSearch(new Float32Array(3), 5);
+    expect(calls).toContain("ato_vector_search");
+  });
+
+  it("uses ato_vector_search_openai when EMBED_PROVIDER=openai", async () => {
+    process.env["EMBED_PROVIDER"] = "openai";
+    const { client, calls } = spyClient();
+    await new SupabaseStore(client).vectorSearch(new Float32Array(3), 5);
+    expect(calls).toContain("ato_vector_search_openai");
   });
 });

--- a/supabase/migrations/20260701054405_openai_embeddings.sql
+++ b/supabase/migrations/20260701054405_openai_embeddings.sql
@@ -1,0 +1,37 @@
+-- Additive OpenAI embedding path. Does NOT touch the live `embedding` column or
+-- `ato_vector_search` — serving continues on MiniLM until the EMBED_PROVIDER flag
+-- flips. The engine repo populates embedding_openai; cutover happens via env.
+
+alter table chunks add column if not exists embedding_openai halfvec(3072);
+
+-- HNSW index (halfvec indexes up to 4000 dims). Built empty; maintained as the
+-- engine re-embed populates the column.
+create index if not exists chunks_embedding_openai_idx
+  on chunks using hnsw (embedding_openai halfvec_cosine_ops);
+
+create or replace function public.ato_vector_search_openai(
+  q_embedding vector(3072), k integer, pit_date date default null
+)
+returns table(
+  chunk_id text, doc_id text, ord integer, text text, heading_path text[],
+  score real, title text, url text, doc_type text, snippet text
+)
+language sql stable as $function$
+  select
+    c.chunk_id, c.doc_id, c.ord, c.text, c.heading_path,
+    (1 - (c.embedding_openai <=> q_embedding::halfvec))::real as score,
+    d.title, d.url, d.doc_type,
+    left(c.text, 280) as snippet
+  from chunks c
+  join docs d using (doc_id)
+  where c.embedding_openai is not null
+    and (
+      pit_date is null
+      or (
+        (c.effective_from is null or c.effective_from <= pit_date)
+        and (c.effective_to is null or c.effective_to > pit_date)
+      )
+    )
+  order by c.embedding_openai <=> q_embedding::halfvec
+  limit k;
+$function$;


### PR DESCRIPTION
Adds the OpenAI `text-embedding-3-large` (halfvec 3072) retrieval path **behind the `EMBED_PROVIDER` flag, off by default** — additive and zero prod impact on merge.

### Changes
- **Additive migration** — `chunks.embedding_openai halfvec(3072)` + HNSW (`halfvec_cosine_ops`) + `ato_vector_search_openai` RPC. Does **not** touch the live `embedding` column or `ato_vector_search`.
- **`OpenAIEmbedder`** — query embedding via the OpenAI API; model/dims from env (`OPENAI_EMBED_MODEL`/`OPENAI_EMBED_DIMS`), mock-safe.
- **`EMBED_PROVIDER` flag** (`minilm` default | `openai`) selects embedder + vector RPC via one helper.
- **Eval** honours the flag for validation.

### Safety
`EMBED_PROVIDER` unset ⇒ behaviour byte-identical to today (WasmEmbedder + `ato_vector_search`). Whole-branch review verified this against the live DB. **No prod change until the flag flips.**

### After merge (not this PR)
Engine (sub-project B) re-embeds `embedding_openai` → run eval with `EMBED_PROVIDER=openai` to prove the recall lift → set `EMBED_PROVIDER=openai` + `OPENAI_API_KEY` in Vercel (cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)