### PR TITLE
db: bulk_update_chunk_embeddings_openai RPC

### DIFF
--- a/supabase/migrations/20260701060448_bulk_update_openai_rpc.sql
+++ b/supabase/migrations/20260701060448_bulk_update_openai_rpc.sql
@@ -1,0 +1,24 @@
+-- Bulk-writes OpenAI (halfvec 3072) vectors into chunks.embedding_openai.
+-- Mirrors bulk_update_chunk_embeddings (which targets the 384 `embedding` column).
+-- Used by the engine's OpenAI re-embed runner; additive, does not touch `embedding`.
+create or replace function public.bulk_update_chunk_embeddings_openai(payload jsonb)
+returns integer
+language plpgsql
+as $function$
+declare
+  n int;
+begin
+  with updates as (
+    select
+      (elem->>'chunk_id')::text as chunk_id,
+      (elem->>'embedding')::halfvec(3072) as embedding
+    from jsonb_array_elements(payload) as elem
+  )
+  update chunks c
+     set embedding_openai = u.embedding
+    from updates u
+   where c.chunk_id = u.chunk_id;
+  get diagnostics n = row_count;
+  return n;
+end;
+$function$;


### PR DESCRIPTION
Additive RPC to bulk-write halfvec(3072) vectors into `embedding_openai` (mirrors the existing 384-dim bulk-update RPC). Used by the engine's OpenAI re-embed runner. Does not touch the live `embedding` column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)