### PR TITLE
B4c: drop _openai compat wrappers

### DIFF
--- a/supabase/migrations/20260702093409_drop_openai_compat_wrappers.sql
+++ b/supabase/migrations/20260702093409_drop_openai_compat_wrappers.sql
@@ -1,0 +1,4 @@
+-- B4 cleanup: the backend now calls the canonical names; drop the twins that
+-- existed only to carry the deployed backend through the rename migration.
+drop function if exists public.ato_vector_search_openai(vector, integer, date);
+drop function if exists public.bulk_update_chunk_embeddings_openai(jsonb);


### PR DESCRIPTION
Final step of the B4 consolidation: the backend (#37) now calls ato_vector_search / bulk_update_chunk_embeddings, so the _openai twins from #36 are unused. Merging only after the #37 production deploy is verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)