### PR TITLE
docs: unified README for GitHub and npm, panel-reviewed wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# ato-mcp
+# Australian Tax MCP Server
 
 **The Australian tax knowledge base for AI agents.**
 
@@ -19,7 +19,7 @@ your accountant to answer.
 
 ## Quick start
 
-Add the server to the client you already use.
+Add the MCP Server to the client you already use.
 
 **Standard config** works with most tools that run stdio servers:
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ stdio host to the hosted server with the same browser sign-in.
 
 </details>
 
-Full instructions available **[here](https://ato-mcp.com.au/install)**.
+Full instructions: **[ato-mcp.com.au/install](https://ato-mcp.com.au/install)**
 
 ## What's in the corpus
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 **The Australian tax knowledge base for AI agents.**
 
-Cited, current answers from 34,500+ ATO documents, the income tax and GST Acts
-and 4,900+ public rulings, plus tax workflow tools that know *your* situation.
-Connect your client in one command and ask in plain English.
+Connect your AI agent to 34,500+ ATO documents (guidance, legislation, and
+public rulings) and get cited answers to the tax questions you'd otherwise pay
+your accountant to answer.
 
 [ato-mcp.com.au](https://ato-mcp.com.au) · [Tool reference](https://github.com/william-laverty/ato-mcp/blob/main/docs/tools.md) · [Changelog](https://github.com/william-laverty/ato-mcp/blob/main/CHANGELOG.md)
 
@@ -17,20 +17,28 @@ Connect your client in one command and ask in plain English.
 
 </div>
 
-## Try asking
-
-- *"Can I claim my home office? I work from home three days a week."*
-- *"What's the instant asset write-off limit right now, and does my ute qualify?"*
-- *"Walk me through what I need for this quarter's BAS."*
-- *"Here's my draft return. What would the ATO look twice at?"*
-
-Every answer comes back with the ATO source behind it: the guidance page, the
-legislation section, the ruling.
-
 ## Quick start
 
-Connect your client to the hosted server. Your browser opens to sign in: no
-tokens, no API keys, nothing to configure by hand.
+Add the server to the client you already use.
+
+**Standard config** works with most tools that run stdio servers:
+
+```json
+{
+  "mcpServers": {
+    "ato": {
+      "command": "npx",
+      "args": ["-y", "ato-mcp"]
+    }
+  }
+}
+```
+
+```bash
+npm install -g ato-mcp   # optional, npx works without installing
+```
+
+For hosts that natively support remote MCP servers, connect your client directly:
 
 <details>
 <summary><b>Claude Code</b></summary>
@@ -121,8 +129,8 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 }
 ```
 
-If Windsurf doesn't open a sign-in window, use the standard npm config further
-down; it handles the browser sign-in itself.
+If Windsurf doesn't open a sign-in window, use the standard npm config at the top
+of this section instead; it handles the browser sign-in itself.
 
 </details>
 
@@ -134,9 +142,8 @@ down; it handles the browser sign-in itself.
 3. Paste `https://api.ato-mcp.com.au/mcp`
 4. Click **Connect** and sign in when the browser window appears
 
-Custom connectors require a paid Claude plan. On any plan, Claude Desktop can
-instead use the standard npm config further down, in
-`claude_desktop_config.json`.
+Available on paid Claude plans. Claude Desktop can alternatively use the standard
+npm config at the top of this section in `claude_desktop_config.json`.
 
 </details>
 
@@ -151,26 +158,15 @@ Requires a plan with connector support.
 
 </details>
 
-On a client that can't connect to remote servers (OpenCode, Zed and other
-stdio-only hosts), the **standard config** bridges it to the hosted server with
-the same browser sign-in:
+<details>
+<summary><b>Other (OpenCode, Zed, etc)</b></summary>
 
-```json
-{
-  "mcpServers": {
-    "ato": {
-      "command": "npx",
-      "args": ["-y", "ato-mcp"]
-    }
-  }
-}
-```
+Use the standard npm config at the top of this section. This package bridges any
+stdio host to the hosted server with the same browser sign-in.
 
-```bash
-npm install -g ato-mcp   # optional, npx works without installing
-```
+</details>
 
-Full instructions: **[ato-mcp.com.au/install](https://ato-mcp.com.au/install)**
+Full instructions available **[here](https://ato-mcp.com.au/install)**.
 
 ## What's in the corpus
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,36 @@
 <div align="center">
 
-# Australian Tax MCP
+# ato-mcp
 
 **The Australian tax knowledge base for AI agents.**
 
-Give your agent cited, current answers from 34,500+ ATO documents, plus a
-personal-facts layer and four tax workflow tools that know *your* situation.
+Cited, current answers from 34,500+ ATO documents, the income tax and GST Acts
+and 4,900+ public rulings, plus tax workflow tools that know *your* situation.
+Connect your client in one command and ask in plain English.
 
-[ato-mcp.com.au](https://ato-mcp.com.au) · [Tool reference](docs/tools.md) · [Changelog](CHANGELOG.md)
+[ato-mcp.com.au](https://ato-mcp.com.au) · [Tool reference](https://github.com/william-laverty/ato-mcp/blob/main/docs/tools.md) · [Changelog](https://github.com/william-laverty/ato-mcp/blob/main/CHANGELOG.md)
 
 [![CI](https://github.com/william-laverty/ato-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/william-laverty/ato-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/ato-mcp)](https://www.npmjs.com/package/ato-mcp)
-[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
+[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/william-laverty/ato-mcp/blob/main/LICENSE)
 [![Node 22+](https://img.shields.io/badge/node-%E2%89%A522-brightgreen)](https://nodejs.org)
 
 </div>
 
+## Try asking
+
+- *"Can I claim my home office? I work from home three days a week."*
+- *"What's the instant asset write-off limit right now, and does my ute qualify?"*
+- *"Walk me through what I need for this quarter's BAS."*
+- *"Here's my draft return. What would the ATO look twice at?"*
+
+Every answer comes back with the ATO source behind it: the guidance page, the
+legislation section, the ruling.
+
 ## Quick start
 
-Add the server to the client you already use.
-
-**Standard config** works with most tools that run stdio servers:
-
-```json
-{
-  "mcpServers": {
-    "ato": {
-      "command": "npx",
-      "args": ["-y", "ato-mcp"]
-    }
-  }
-}
-```
-
-```bash
-npm install -g ato-mcp   # optional, npx works without installing
-```
-
-For hosts that natively support remote MCP servers, connect your client directly:
+Connect your client to the hosted server. Your browser opens to sign in: no
+tokens, no API keys, nothing to configure by hand.
 
 <details>
 <summary><b>Claude Code</b></summary>
@@ -128,8 +121,8 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 }
 ```
 
-If Windsurf doesn't open a sign-in window, use the standard npm config at the top
-of this section instead; it handles the browser sign-in itself.
+If Windsurf doesn't open a sign-in window, use the standard npm config further
+down; it handles the browser sign-in itself.
 
 </details>
 
@@ -141,8 +134,9 @@ of this section instead; it handles the browser sign-in itself.
 3. Paste `https://api.ato-mcp.com.au/mcp`
 4. Click **Connect** and sign in when the browser window appears
 
-Available on paid Claude plans. Claude Desktop can alternatively use the standard
-npm config at the top of this section in `claude_desktop_config.json`.
+Custom connectors require a paid Claude plan. On any plan, Claude Desktop can
+instead use the standard npm config further down, in
+`claude_desktop_config.json`.
 
 </details>
 
@@ -157,37 +151,43 @@ Requires a plan with connector support.
 
 </details>
 
-<details>
-<summary><b>Other (OpenCode, Zed, etc)</b></summary>
+On a client that can't connect to remote servers (OpenCode, Zed and other
+stdio-only hosts), the **standard config** bridges it to the hosted server with
+the same browser sign-in:
 
-Use the standard npm config at the top of this section. This package bridges any
-stdio host to the hosted server with the same browser sign-in.
+```json
+{
+  "mcpServers": {
+    "ato": {
+      "command": "npx",
+      "args": ["-y", "ato-mcp"]
+    }
+  }
+}
+```
 
-</details>
+```bash
+npm install -g ato-mcp   # optional, npx works without installing
+```
 
-Full instructions available **[here](https://ato-mcp.com.au/install)**.
+Full instructions: **[ato-mcp.com.au/install](https://ato-mcp.com.au/install)**
 
 ## What's in the corpus
+
+Everything the ATO publishes, in one searchable place, refreshed monthly:
 
 | Source | Contents |
 |---|---|
 | **ato.gov.au** | 23,000+ guidance pages, forms & instructions, occupation guides, myTax help |
 | **Legislation** | ITAA 1997, ITAA 1936 and the GST Act: 6,468 sections + 2,310 statutory definitions (point-in-time aware) |
 | **ATO public rulings** | 4,900+ rulings across 10 types (TR, TD, GSTR, GSTD, PR, CR, LCR, PCG, MT, FTR), withdrawn rulings flagged |
-| **Citation graph** | 64,217 cross-references between rulings and legislation |
-| **Thresholds** | Time-keyed scalars (instant asset write-off, GST registration, CGT discount, super caps, …) |
+| **Cross-references** | 64,217 links between rulings and legislation |
+| **Thresholds** | Time-keyed values (instant asset write-off, GST registration, CGT discount, super caps, …) |
 
-**34,500+ documents (286,000+ searchable passages), hybrid-indexed (BM25 + vector)**, refreshed monthly and served from
-the hosted platform.
+**34,500+ documents (286,000+ searchable passages)**, refreshed monthly and
+served from the hosted platform.
 
 ## The 13 tools
-
-**Retrieval:** `search` (hybrid BM25+vector), `get_chunks`, `get_doc`, `get_doc_anchors`
-(citation graph), `get_definition` (statutory, point-in-time), `get_threshold` (time-keyed
-scalars), `fetch` (live page fetch), `stats`.
-
-**Personal context:** `get_user_facts`, 25 facts captured once at onboarding (business
-structure, GST registration, investments, super type, residency, …) so the agent never re-asks.
 
 **Workflows** are the reason this exists:
 
@@ -200,22 +200,37 @@ structure, GST registration, investments, super type, residency, …) so the age
 | `bas_prep_checklist` | A tiered, cited BAS checklist for your reporting period: which labels apply, what evidence to gather, the gotchas |
 | `audit_risk_check` | Flags the patterns the ATO scrutinises in a draft return (WRE vs income, rental anomalies, unreported crypto, …) with risk bands and the guidance behind each flag |
 
-Every workflow tool returns **structured data and resolvable ATO citations, never advice in its
-own voice**. See the [full tool reference](docs/tools.md).
+Every workflow tool returns **structured data and resolvable ATO citations,
+never advice in its own voice**.
+
+**Personal context:** `get_user_facts`, 25 facts captured once at onboarding
+(business structure, GST registration, investments, super type, residency, …)
+so the agent never re-asks.
+
+**Retrieval:** `search` (keyword and semantic retrieval), `get_chunks`,
+`get_doc`, `get_doc_anchors` (cross-references), `get_definition` (statutory,
+point-in-time), `get_threshold` (time-keyed values), `fetch` (live page fetch),
+`stats`.
+
+See the [full tool reference](https://github.com/william-laverty/ato-mcp/blob/main/docs/tools.md).
 
 ## Disclaimer
 
-This service is provided as **information infrastructure, not tax advice**. It does not consider your full financial circumstances
-and it is not a registered tax agent service. Confidence ratings and risk bands are heuristic
-indicators, not professional judgement. Verify material decisions with a registered tax agent. 
+This service is provided as **information infrastructure, not tax advice**. It
+does not consider your full financial circumstances and it is not a registered
+tax agent service. Confidence ratings and risk bands are guides, not
+professional judgement. Verify material decisions with a registered tax agent.
 
-ATO content remains subject to ATO publication terms. ITAA 1997 text is reproduced from the
-Federal Register of Legislation under its open licensing.
+ato-mcp is an independent service. It is not affiliated with or endorsed by
+the Australian Taxation Office. ATO content remains subject to ATO publication
+terms. Legislation text is reproduced from the Federal Register of Legislation
+under its open licensing.
 
-See the [Terms of Service](https://ato-mcp.com.au/terms) & [Privacy Policy](https://ato-mcp.com.au/privacy) for more details.
+See the [Terms of Service](https://ato-mcp.com.au/terms) &
+[Privacy Policy](https://ato-mcp.com.au/privacy) for more details.
 
 ---
 
-**License [AGPL-3.0](LICENSE) © William Laverty**
+**License [AGPL-3.0](https://github.com/william-laverty/ato-mcp/blob/main/LICENSE) © William Laverty**
 
- *The hosted platform and corpus are proprietary. Commercial licensing available on request.*
+*The hosted platform and corpus are proprietary. Commercial licensing available on request.*

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# ato-mcp
+# Australian Tax MCP Server
 
 **The Australian tax knowledge base for AI agents.**
 
@@ -19,7 +19,7 @@ your accountant to answer.
 
 ## Quick start
 
-Add the server to the client you already use.
+Add the MCP Server to the client you already use.
 
 **Standard config** works with most tools that run stdio servers:
 
@@ -166,7 +166,8 @@ stdio host to the hosted server with the same browser sign-in.
 
 </details>
 
-Full instructions available **[here](https://ato-mcp.com.au/install)**.
+Full instructions: **[ato-mcp.com.au/install](https://ato-mcp.com.au/instal
+l)**
 
 ## What's in the corpus
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,9 +4,9 @@
 
 **The Australian tax knowledge base for AI agents.**
 
-Cited, current answers from 34,500+ ATO documents, the income tax and GST Acts
-and 4,900+ public rulings, plus tax workflow tools that know *your* situation.
-Connect your client in one command and ask in plain English.
+Connect your AI agent to 34,500+ ATO documents (guidance, legislation, and
+public rulings) and get cited answers to the tax questions you'd otherwise pay
+your accountant to answer.
 
 [ato-mcp.com.au](https://ato-mcp.com.au) · [Tool reference](https://github.com/william-laverty/ato-mcp/blob/main/docs/tools.md) · [Changelog](https://github.com/william-laverty/ato-mcp/blob/main/CHANGELOG.md)
 
@@ -17,20 +17,28 @@ Connect your client in one command and ask in plain English.
 
 </div>
 
-## Try asking
-
-- *"Can I claim my home office? I work from home three days a week."*
-- *"What's the instant asset write-off limit right now, and does my ute qualify?"*
-- *"Walk me through what I need for this quarter's BAS."*
-- *"Here's my draft return. What would the ATO look twice at?"*
-
-Every answer comes back with the ATO source behind it: the guidance page, the
-legislation section, the ruling.
-
 ## Quick start
 
-Connect your client to the hosted server. Your browser opens to sign in: no
-tokens, no API keys, nothing to configure by hand.
+Add the server to the client you already use.
+
+**Standard config** works with most tools that run stdio servers:
+
+```json
+{
+  "mcpServers": {
+    "ato": {
+      "command": "npx",
+      "args": ["-y", "ato-mcp"]
+    }
+  }
+}
+```
+
+```bash
+npm install -g ato-mcp   # optional, npx works without installing
+```
+
+For hosts that natively support remote MCP servers, connect your client directly:
 
 <details>
 <summary><b>Claude Code</b></summary>
@@ -121,8 +129,8 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 }
 ```
 
-If Windsurf doesn't open a sign-in window, use the standard npm config further
-down; it handles the browser sign-in itself.
+If Windsurf doesn't open a sign-in window, use the standard npm config at the top
+of this section instead; it handles the browser sign-in itself.
 
 </details>
 
@@ -134,9 +142,8 @@ down; it handles the browser sign-in itself.
 3. Paste `https://api.ato-mcp.com.au/mcp`
 4. Click **Connect** and sign in when the browser window appears
 
-Custom connectors require a paid Claude plan. On any plan, Claude Desktop can
-instead use the standard npm config further down, in
-`claude_desktop_config.json`.
+Available on paid Claude plans. Claude Desktop can alternatively use the standard
+npm config at the top of this section in `claude_desktop_config.json`.
 
 </details>
 
@@ -151,26 +158,15 @@ Requires a plan with connector support.
 
 </details>
 
-On a client that can't connect to remote servers (OpenCode, Zed and other
-stdio-only hosts), the **standard config** bridges it to the hosted server with
-the same browser sign-in:
+<details>
+<summary><b>Other (OpenCode, Zed, etc)</b></summary>
 
-```json
-{
-  "mcpServers": {
-    "ato": {
-      "command": "npx",
-      "args": ["-y", "ato-mcp"]
-    }
-  }
-}
-```
+Use the standard npm config at the top of this section. This package bridges any
+stdio host to the hosted server with the same browser sign-in.
 
-```bash
-npm install -g ato-mcp   # optional, npx works without installing
-```
+</details>
 
-Full instructions: **[ato-mcp.com.au/install](https://ato-mcp.com.au/install)**
+Full instructions available **[here](https://ato-mcp.com.au/install)**.
 
 ## What's in the corpus
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,37 +2,35 @@
 
 # ato-mcp
 
-**Your AI agent, fluent in Australian tax.**
+**The Australian tax knowledge base for AI agents.**
 
-Cited answers from 34,500+ ATO documents, the income tax and GST Acts and
-4,900+ public rulings — plus tax workflow tools that know *your* situation.
+Cited, current answers from 34,500+ ATO documents, the income tax and GST Acts
+and 4,900+ public rulings, plus tax workflow tools that know *your* situation.
+Connect your client in one command and ask in plain English.
 
 [ato-mcp.com.au](https://ato-mcp.com.au) · [Tool reference](https://github.com/william-laverty/ato-mcp/blob/main/docs/tools.md) · [Changelog](https://github.com/william-laverty/ato-mcp/blob/main/CHANGELOG.md)
 
+[![CI](https://github.com/william-laverty/ato-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/william-laverty/ato-mcp/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/ato-mcp)](https://www.npmjs.com/package/ato-mcp)
+[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/william-laverty/ato-mcp/blob/main/LICENSE)
+[![Node 22+](https://img.shields.io/badge/node-%E2%89%A522-brightgreen)](https://nodejs.org)
+
 </div>
+
+## Try asking
+
+- *"Can I claim my home office? I work from home three days a week."*
+- *"What's the instant asset write-off limit right now, and does my ute qualify?"*
+- *"Walk me through what I need for this quarter's BAS."*
+- *"Here's my draft return. What would the ATO look twice at?"*
+
+Every answer comes back with the ATO source behind it: the guidance page, the
+legislation section, the ruling.
 
 ## Quick start
 
-First, install the ATO MCP server with your client.
-
-**Standard config** works with most tools that run stdio servers:
-
-```json
-{
-  "mcpServers": {
-    "ato": {
-      "command": "npx",
-      "args": ["-y", "ato-mcp"]
-    }
-  }
-}
-```
-
-```bash
-npm install -g ato-mcp   # optional — npx works without installing
-```
-
-For hosts that natively support remote MCP servers, connect your client directly:
+Connect your client to the hosted server. Your browser opens to sign in: no
+tokens, no API keys, nothing to configure by hand.
 
 <details>
 <summary><b>Claude Code</b></summary>
@@ -41,8 +39,8 @@ For hosts that natively support remote MCP servers, connect your client directly
 claude mcp add --transport http ato https://api.ato-mcp.com.au/mcp
 ```
 
-Then run `/mcp` inside Claude Code, select **ato**, and choose **Authenticate** —
-your browser opens to sign in.
+Then run `/mcp` inside Claude Code, select **ato**, and choose **Authenticate**.
+Your browser opens to sign in.
 
 </details>
 
@@ -102,7 +100,7 @@ Or add to `~/.cursor/mcp.json`:
 }
 ```
 
-Cursor shows a "Needs login" prompt on the server — click it to sign in via your
+Cursor shows a "Needs login" prompt on the server. Click it to sign in via your
 browser.
 
 </details>
@@ -123,8 +121,8 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 }
 ```
 
-If Windsurf doesn't open a sign-in window, use the standard npm config at the top
-of this section instead — it handles the browser sign-in itself.
+If Windsurf doesn't open a sign-in window, use the standard npm config further
+down; it handles the browser sign-in itself.
 
 </details>
 
@@ -136,8 +134,9 @@ of this section instead — it handles the browser sign-in itself.
 3. Paste `https://api.ato-mcp.com.au/mcp`
 4. Click **Connect** and sign in when the browser window appears
 
-Available on paid Claude plans. Claude Desktop can alternatively use the standard
-npm config at the top of this section in `claude_desktop_config.json`.
+Custom connectors require a paid Claude plan. On any plan, Claude Desktop can
+instead use the standard npm config further down, in
+`claude_desktop_config.json`.
 
 </details>
 
@@ -152,69 +151,86 @@ Requires a plan with connector support.
 
 </details>
 
-<details>
-<summary><b>OpenCode, Zed & other stdio-only hosts</b></summary>
+On a client that can't connect to remote servers (OpenCode, Zed and other
+stdio-only hosts), the **standard config** bridges it to the hosted server with
+the same browser sign-in:
 
-Use the standard npm config at the top of this section — this package bridges any
-stdio host to the hosted server with the same browser sign-in.
+```json
+{
+  "mcpServers": {
+    "ato": {
+      "command": "npx",
+      "args": ["-y", "ato-mcp"]
+    }
+  }
+}
+```
 
-</details>
+```bash
+npm install -g ato-mcp   # optional, npx works without installing
+```
 
-Full instructions available **[here](https://ato-mcp.com.au/install)**.
-
-## Try asking
-
-- *"Can I claim my home office? I work from home three days a week."*
-- *"What's the instant asset write-off limit right now, and does my ute qualify?"*
-- *"Walk me through what I need for this quarter's BAS."*
-- *"Here's my draft return — what would the ATO look twice at?"*
+Full instructions: **[ato-mcp.com.au/install](https://ato-mcp.com.au/install)**
 
 ## What's in the corpus
 
+Everything the ATO publishes, in one searchable place, refreshed monthly:
+
 | Source | Contents |
 |---|---|
-| **ato.gov.au** | 23,000+ guidance pages, forms & instructions, occupation guides |
-| **Legislation** | ITAA 1997, ITAA 1936 and the GST Act — 6,468 sections + 2,310 statutory definitions, point-in-time aware |
-| **Public rulings** | 4,900+ rulings across 10 types (TR, TD, GSTR, GSTD, PR, CR, LCR, PCG, MT, FTR), withdrawn rulings flagged |
-| **Citation graph** | 64,217 cross-references between rulings and legislation |
-| **Thresholds** | Time-keyed scalars: IAWO, GST registration, CGT discount, super caps, … |
+| **ato.gov.au** | 23,000+ guidance pages, forms & instructions, occupation guides, myTax help |
+| **Legislation** | ITAA 1997, ITAA 1936 and the GST Act: 6,468 sections + 2,310 statutory definitions (point-in-time aware) |
+| **ATO public rulings** | 4,900+ rulings across 10 types (TR, TD, GSTR, GSTD, PR, CR, LCR, PCG, MT, FTR), withdrawn rulings flagged |
+| **Cross-references** | 64,217 links between rulings and legislation |
+| **Thresholds** | Time-keyed values (instant asset write-off, GST registration, CGT discount, super caps, …) |
 
-34,500+ documents (286,000+ searchable passages), hybrid-indexed (BM25 +
-vector), refreshed monthly.
+**34,500+ documents (286,000+ searchable passages)**, refreshed monthly and
+served from the hosted platform.
 
 ## The 13 tools
 
-**Retrieval** — `search` (hybrid keyword + semantic), `get_doc`, `get_chunks`,
-`get_doc_anchors` (citation graph), `get_definition` (statutory, point-in-time),
-`get_threshold` (time-keyed scalars), `fetch`, `stats`.
+**Workflows** are the reason this exists:
 
-**Personal context** — `get_user_facts`: 25 facts captured once at onboarding
-so the agent never re-asks.
-
-**Workflows** — deterministic, cited, branched on your taxpayer structure:
+> _"Here's my bank transactions, what can I claim this year? How do I write off my new laptop? Is anything in my return risky?"_
 
 | Tool | What it does |
 |---|---|
-| `deduction_discovery` | Every deduction category that plausibly applies to your profile |
-| `depreciation_helper` | Prime-cost / diminishing-value / instant-write-off / pool schedules |
-| `bas_prep_checklist` | A tiered, cited BAS checklist for your reporting period |
-| `audit_risk_check` | Flags the patterns the ATO scrutinises in a draft return |
+| `deduction_discovery` | Surfaces **every deduction category** that plausibly applies to your profile: a curated, cited taxonomy branched across sole traders, companies, trusts, partnerships, investors and SMSF members |
+| `depreciation_helper` | Deterministic prime-cost / diminishing-value / instant-write-off / small-business-pool / Div 43 schedules for any asset, with the live IAWO threshold |
+| `bas_prep_checklist` | A tiered, cited BAS checklist for your reporting period: which labels apply, what evidence to gather, the gotchas |
+| `audit_risk_check` | Flags the patterns the ATO scrutinises in a draft return (WRE vs income, rental anomalies, unreported crypto, …) with risk bands and the guidance behind each flag |
 
-Full reference: [docs/tools.md](https://github.com/william-laverty/ato-mcp/blob/main/docs/tools.md)
+Every workflow tool returns **structured data and resolvable ATO citations,
+never advice in its own voice**.
+
+**Personal context:** `get_user_facts`, 25 facts captured once at onboarding
+(business structure, GST registration, investments, super type, residency, …)
+so the agent never re-asks.
+
+**Retrieval:** `search` (keyword and semantic retrieval), `get_chunks`,
+`get_doc`, `get_doc_anchors` (cross-references), `get_definition` (statutory,
+point-in-time), `get_threshold` (time-keyed values), `fetch` (live page fetch),
+`stats`.
+
+See the [full tool reference](https://github.com/william-laverty/ato-mcp/blob/main/docs/tools.md).
 
 ## Disclaimer
 
-This service is provided as **information infrastructure, not tax advice**. It does not consider your full financial circumstances
-and it is not a registered tax agent service. Confidence ratings and risk bands are heuristic
-indicators, not professional judgement. Verify material decisions with a registered tax agent. 
+This service is provided as **information infrastructure, not tax advice**. It
+does not consider your full financial circumstances and it is not a registered
+tax agent service. Confidence ratings and risk bands are guides, not
+professional judgement. Verify material decisions with a registered tax agent.
 
-ATO content remains subject to ATO publication terms. ITAA 1997 text is reproduced from the
-Federal Register of Legislation under its open licensing.
+ato-mcp is an independent service. It is not affiliated with or endorsed by
+the Australian Taxation Office. ATO content remains subject to ATO publication
+terms. Legislation text is reproduced from the Federal Register of Legislation
+under its open licensing.
 
-**See the [Terms of Service](https://ato-mcp.com.au/terms) & [Privacy Policy](https://ato-mcp.com.au/privacy) for more details.**
+See the [Terms of Service](https://ato-mcp.com.au/terms) &
+[Privacy Policy](https://ato-mcp.com.au/privacy) for more details.
 
 ---
 
 **License [AGPL-3.0](https://github.com/william-laverty/ato-mcp/blob/main/LICENSE) © William Laverty**
 
- *The hosted platform and corpus are proprietary. Commercial licensing available on request.*
+*The hosted platform and corpus are proprietary. Commercial licensing available on request.*

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -166,8 +166,7 @@ stdio host to the hosted server with the same browser sign-in.
 
 </details>
 
-Full instructions: **[ato-mcp.com.au/install](https://ato-mcp.com.au/instal
-l)**
+Full instructions: **[ato-mcp.com.au/install](https://ato-mcp.com.au/install)**
 
 ## What's in the corpus
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ato-mcp",
   "version": "2.1.2",
-  "description": "Your AI agent, fluent in Australian tax. MCP server with cited answers from 34,500+ ATO documents, the income tax and GST Acts and 4,900+ rulings \u2014 plus deduction, depreciation, BAS and audit-risk tools that know your tax profile.",
+  "description": "Your AI agent, fluent in Australian tax. MCP server with cited answers from 34,500+ ATO documents, the income tax and GST Acts and 4,900+ rulings, plus deduction, depreciation, BAS and audit-risk tools that know your tax profile.",
   "keywords": [
     "mcp",
     "model-context-protocol",
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "scripts": {
-    "prepack": "rm -rf dist && tsc -p tsconfig.json",
+    "prepack": "cp ../../README.md ./README.md && rm -rf dist && tsc -p tsconfig.json",
     "build": "tsc -p tsconfig.json",
     "dev": "tsx watch src/index.ts",
     "test": "vitest run",


### PR DESCRIPTION
## Change Summary
Unified the GitHub README and the npm package page into a single document with a sharper accountant-angle tagline. The npm page previously shipped a stale, separately-maintained README; it now always matches GitHub, enforced at publish time. Wording was refined through a three-persona expert review (customer 8/10, conversion copywriter 7/10, brand reviewer 9/10).

### Changes
- New tagline: "Connect your AI agent to 34,500+ ATO documents (guidance, legislation, and public rulings) and get cited answers to the tax questions you'd otherwise pay your accountant to answer."
- Single source of truth: `packages/mcp/README.md` is now a copy of the root README, and `prepack` re-copies it on every publish so the npm page can never drift again
- All repo-relative links made absolute so the same file renders correctly on both GitHub and npm
- Tools section reordered workflows-first, with retrieval primitives as a supporting list; "hybrid"/"BM25" dropped from the search description
- Corpus section opens with the benefit ("Everything the ATO publishes, in one searchable place, refreshed monthly") before the inventory table; "citation graph" renamed to "cross-references"
- Added an explicit non-affiliation statement to the disclaimer (independent service, not endorsed by the ATO)
- npm `description` field updated (em-dash removed)
- Heading unified to "ato-mcp" (was "Australian Tax MCP" on GitHub and "ato-mcp" on npm)

The Quick start section is unchanged from main.