### PR TITLE
chore: release v2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.1.4
+
+- README: the Claude Code and Gemini CLI install commands now use `--scope user`, so a
+  single install makes the server available in every project. No code changes.
+
 ## v2.1.3
 
 - README unified across GitHub and npm: `prepack` now copies the root README into the

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ato-mcp",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Your AI agent, fluent in Australian tax. MCP server with cited answers from 34,500+ ATO documents, the income tax and GST Acts and 4,900+ rulings, plus deduction, depreciation, BAS and audit-risk tools that know your tax profile.",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Change Summary
Cut v2.1.4 so the npm page picks up the updated README (user-scope install commands for Claude Code and Gemini CLI). Docs-only release, no code changes.

### Changes
- Bumped `ato-mcp` to 2.1.4
- Added the v2.1.4 changelog entry