### PR TITLE
chore: add glama.json for the Glama MCP directory

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["william-laverty"]
+}


### PR DESCRIPTION
## Change Summary
Added the two-line glama.json manifest so the ato-mcp listing on glama.ai can be claimed and maintained.

### Changes
- Added `glama.json` (schema reference + maintainer GitHub username)

🤖 Generated with [Claude Code](https://claude.com/claude-code)