### PR TITLE
docs: add UTM parameters to site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Connect your AI agent to 34,500+ ATO documents (guidance, legislation, and
 public rulings) and get cited answers to the tax questions you'd otherwise pay
 your accountant to answer.
 
-[ato-mcp.com.au](https://ato-mcp.com.au) · [Tool reference](https://github.com/william-laverty/ato-mcp/blob/main/docs/tools.md) · [Changelog](https://github.com/william-laverty/ato-mcp/blob/main/CHANGELOG.md)
+[ato-mcp.com.au](https://ato-mcp.com.au?utm_source=github&utm_medium=readme) · [Tool reference](https://github.com/william-laverty/ato-mcp/blob/main/docs/tools.md) · [Changelog](https://github.com/william-laverty/ato-mcp/blob/main/CHANGELOG.md)
 
 [![CI](https://github.com/william-laverty/ato-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/william-laverty/ato-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/ato-mcp)](https://www.npmjs.com/package/ato-mcp)
@@ -166,7 +166,7 @@ stdio host to the hosted server with the same browser sign-in.
 
 </details>
 
-Full instructions: **[ato-mcp.com.au/install](https://ato-mcp.com.au/install)**
+Full instructions: **[ato-mcp.com.au/install](https://ato-mcp.com.au/install?utm_source=github&utm_medium=readme)**
 
 ## What's in the corpus
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -19,7 +19,7 @@
   ],
   "license": "AGPL-3.0-only",
   "author": "William Laverty",
-  "homepage": "https://ato-mcp.com.au",
+  "homepage": "https://ato-mcp.com.au?utm_source=npm&utm_medium=package",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/william-laverty/ato-mcp.git",


### PR DESCRIPTION
## Change Summary
Added UTM parameters to the links pointing at ato-mcp.com.au so visits from the GitHub README and the npm package page are attributed to their source in analytics instead of landing in Direct.

### Changes
- README: the homepage and install links now carry `utm_source=github&utm_medium=readme`.
- `packages/mcp/package.json`: the `homepage` field now carries `utm_source=npm&utm_medium=package` (shows up on npmjs.com from the next published release).